### PR TITLE
Improved Persona error handling

### DIFF
--- a/lib/persona.coffee
+++ b/lib/persona.coffee
@@ -2,6 +2,22 @@ module.exports = (owner) ->
   $("#user-email").hide()
   $("#persona-login-btn").hide()
   $("#persona-logout-btn").hide()
+
+  failureDlg = (message) ->
+    $("<div></div>").dialog({
+      # Remove the closing 'X' from the dialog
+      open: (event, ui) -> $(".ui-dialog-titlebar-close").hide()
+      buttons: {
+        "Ok": -> 
+          $(this).dialog("close")
+          navigator.id.logout()
+      }
+      close: (event, ui) -> $(this).remove()
+      resizable:  false
+      title: "Login Failure"
+      modal: true
+    }).html(message)
+
   navigator.id.watch
     loggedInUser: owner
     onlogin: (assertion) ->
@@ -11,11 +27,23 @@ module.exports = (owner) ->
         verified = JSON.parse(verified)
         if "okay" is verified.status
           window.location = "/";
+        else if "wrong-address" is verified.status
+          # Logged in user is not the site owner, something to address later...
+          failureDlg "<p>Sign in is currently only available for the site owner.</p>"
+        else if "failure" is verified.status
+          # The verification service has failed to verify the asertion
+          if /domain mismatch/.test(verified.reason)
+            # The site is being accessed using a different protocol/address than that used as 
+            # the audience in the call to the verification service...
+            failureMsg = "<p>It looks as if you are accessing the site using an alternative address.</p>" + \
+            "<p>Please check that you are using the correct address to access this site.</p>"
+          else
+            # Verification failed for some other reason
+            failureMsg = "<p>Unable to log you in.</p>"
+          failureDlg failureMsg
         else
-
-          # Verification failed
+          # something else has happened - be safe log the user out...
           navigator.id.logout()
-          window.location = "/oops"  if "wrong-address" is verified.status
 
 
     onlogout: ->


### PR DESCRIPTION
The client updates associated with WardCunningham/wiki#37

When the verifier fails, rather than causing an AJAX error the server will return the reason for the failure. 

The client is updated to capture the failure, display an error dialog, and log the user out of site (to prevent login failure loops).

A side effect - if somebody other than the site owner logs in, this is now handled better.

Also resolves #3 by calling `navigator.id.logout()` to log the user out of the site.
