### PR TITLE
create external links for ftp: urls

### DIFF
--- a/lib/wiki.coffee
+++ b/lib/wiki.coffee
@@ -63,7 +63,7 @@ wiki.resolveLinks = (string) ->
     "<a class=\"internal\" href=\"/#{slug}.html\" data-page-name=\"#{slug}\" title=\"#{wiki.resolutionContext.join(' => ')}\">#{name}</a>"
   string
     .replace(/\[\[([^\]]+)\]\]/gi, renderInternalLink)
-    .replace(/\[(http.*?) (.*?)\]/gi, """<a class="external" target="_blank" href="$1" title="$1" rel="nofollow">$2 <img src="/images/external-link-ltr-icon.png"></a>""")
+    .replace(/\[((http|https|ftp):.*?) (.*?)\]/gi, """<a class="external" target="_blank" href="$1" title="$1" rel="nofollow">$3 <img src="/images/external-link-ltr-icon.png"></a>""")
 
 module.exports = wiki
 


### PR DESCRIPTION
Revise the external link resolution pattern to be specific about what protocols are accepted. The list will consist of http, https and ftp. This commit consists of both a broadening (accepting ftp) and a narrowing (requiring the colon) of the allowed external link url strings.
