### PR TITLE
only load script once

### DIFF
--- a/lib/plugin.coffee
+++ b/lib/plugin.coffee
@@ -6,12 +6,25 @@ module.exports = plugin = {}
 # TODO: Remove these methods from wiki object?
 #
 
+
+# define cachedScript that allows fetching a cached script.
+# see example in http://api.jquery.com/jQuery.getScript/ 
+
+cachedScript = (url, options) ->
+  options = $.extend(options or {},
+    dataType: "script"
+    cache: true
+    url: url
+  )
+  $.ajax options
+
 scripts = []
 getScript = wiki.getScript = (url, callback = () ->) ->
+  # console.log "URL :", url, "\nCallback :", callback
   if url in scripts
     callback()
-  else
-    $.getScript(url)
+  else 
+    cachedScript(url)
       .done ->
         scripts.push url
         callback()


### PR DESCRIPTION
When loading a script file (plug-in) only load it if it has not already been loaded. Also, allow the browser to cache these requests.

Provides a fix for #13 
