### PR TITLE
expect pageObject when fetching template page

### DIFF
--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -185,7 +185,7 @@ $ ->
     return done(null) unless slug
     wiki.log 'getTemplate', slug
     pageHandler.get
-      whenGotten: (data,siteFound) -> done(data.story)
+      whenGotten: (pageObject,siteFound) -> done(pageObject.getRawPage().story)
       whenNotGotten: -> done(null)
       pageInformation: {slug: slug}
 


### PR DESCRIPTION
Wiki's template mechanism is described in the How To Wiki pages.
http://fed.wiki.org/add-pages.html

This pull request corrects the getTemplate function to use the pageObject now returned by the pageHandler.get function. Eventually we will remove calls to getRawPage but for now it will be good to have templates working again.
