### PR TITLE
turn off sourcemap generation

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -16,7 +16,7 @@ module.exports = function (grunt) {
         src: ['./client.coffee'],
         dest: 'client/client.js',
         options: {
-          debug: true,
+          debug: false,
           transform: ['coffeeify']
         }
       },
@@ -24,7 +24,7 @@ module.exports = function (grunt) {
         src: ['./testclient.coffee'],
         dest: 'client/test/testclient.js',
         options: {
-          debug: true,
+          debug: false,
           transform: ['coffeeify']
         }
       }
@@ -43,7 +43,7 @@ module.exports = function (grunt) {
       client: {
         expand: true,
         options: {
-          sourceMap: true
+          sourceMap: false
         },
         src: ['test/*.coffee', 'lib/*.coffee'],
         ext: '.js'


### PR DESCRIPTION
these are really not needed for normal running, and also vastly increasing the size of the client.js 

may also be the cause of fedwiki/wiki-node#9 as when opening the browser debugger tries to load the source code (generated javascript, not the coffeescript) from a location that does not exist, and seems to vary depending on who built the client.
