### PR TITLE
escape key ends editing

### DIFF
--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -85,21 +85,24 @@ $ ->
   textEditor = wiki.textEditor = (div, item, caretPos, doubleClicked) ->
     return if div.hasClass 'textEditing'
     div.addClass 'textEditing'
+    endEditing = ->
+      div.removeClass 'textEditing'
+      if item.text = textarea.val()
+        plugin.do div.empty(), item
+        return if item.text == original
+        pageHandler.put div.parents('.page:first'), {type: 'edit', id: item.id, item: item}
+      else
+        pageHandler.put div.parents('.page:first'), {type: 'remove', id: item.id}
+        div.remove()
+      null
     textarea = $("<textarea>#{original = item.text ? ''}</textarea>")
-      .focusout ->
-        div.removeClass 'textEditing'
-        if item.text = textarea.val()
-          plugin.do div.empty(), item
-          return if item.text == original
-          pageHandler.put div.parents('.page:first'), {type: 'edit', id: item.id, item: item}
-        else
-          pageHandler.put div.parents('.page:first'), {type: 'remove', id: item.id}
-          div.remove()
-        null
+      .focusout endEditing
       # .bind 'paste', (e) ->
       #   wiki.log 'textedit paste', e
       #   wiki.log e.originalEvent.clipboardData.getData('text')
       .bind 'keydown', (e) ->
+        if e.keyCode == $.ui.keyCode.ESCAPE
+          endEditing()
         if (e.altKey || e.ctlKey || e.metaKey) and e.which == 83 #alt-s
           textarea.focusout()
           return false


### PR DESCRIPTION
I was having trouble in Safari unfocusing `textarea`s. Sometimes clicking on other parts of the page wouldn't work. This patch keeps the current behavior but also ends editing when you press the escape key.

It seems weird to edit a file called "legacy" but that seems to be where all the code for the page is?
