### PR TITLE
Build revisited

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ lib/*.map
 test/*.js
 test/*.map
 client/client.js
+client/client.min.js
 client/client.map
+client/client.min.map
 client/test/testclient.js
 client/test/testclient.map

--- a/package.json
+++ b/package.json
@@ -40,7 +40,9 @@
     "grunt-browserify": "~1.3",
     "grunt-contrib-watch": "~0.5",
     "grunt-mocha-test": "~0.9",
-    "grunt-exorcise": "~0.1"
+    "grunt-exorcise": "~0.1",
+    "grunt-contrib-clean": "~0.5",
+    "grunt-contrib-uglify": "^0.4.0"
   },
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
A second look at the build script.

Source maps have been removed from the grunt-browserify step, as they simply don't work. The source file references are all absolute, to the file system location, and not accessible in the browser.

Uglify has been added to produce a compact version of the client `client.min.js`, this will need a change to servers to be picked up.
