### PR TITLE
Offer help when plugins throw errors.

### DIFF
--- a/lib/plugin.coffee
+++ b/lib/plugin.coffee
@@ -44,7 +44,7 @@ plugin.do = plugin.doPlugin = (div, item, done=->) ->
     """
     div.find('button').on 'click', ->
       wiki.dialog ex.toString(), """
-        <p> This "#{item.type}" plugin won't show.<p>
+        <p> This "#{item.type}" plugin won't show.</p>
         <li> Is it available on this server?
         <li> Is its markup correct?
         <li> Can it find necessary data?
@@ -52,6 +52,14 @@ plugin.do = plugin.doPlugin = (div, item, done=->) ->
         <li> Has its code been tested?
         <p> Developers may open debugging tools and retry the plugin.</p>
         <button class="retry">retry</button>
+        <p> Learn more
+          <a class="external" target="_blank" rel="nofollow"
+          href="http://plugins.fed.wiki.org/about-plugins.html"
+          title="http://plugins.fed.wiki.org/about-plugins.html">
+            About Plugins
+            <img src="/images/external-link-ltr-icon.png">
+          </a>
+        </p>
       """
       $('.retry').on 'click', ->
         if script.emit.length > 2


### PR DESCRIPTION
When things go wrong rendering a plugin the error is caught and a mysterious messaged displayed.

![screen shot 2014-05-02 at 8 26 03 pm](https://cloud.githubusercontent.com/assets/12127/2869478/eb9d7e46-d272-11e3-8626-0435e6ed1b68.png)

This commit adds a help button to the message. Help opens a dialog with some hints and an offer
to retry the errant plugin without the error recovery so that the inspector/debugger can do its thing.

![screen shot 2014-05-02 at 8 26 40 pm](https://cloud.githubusercontent.com/assets/12127/2869505/56bf122a-d273-11e3-961b-ace3ec753299.png)
