### PR TITLE
hover over actions will scroll related pages

### DIFF
--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -123,7 +123,7 @@ $ ->
           pageHandler.put $page, {type:'fork', site: remoteSite} # pull
 
     .delegate '.action', 'hover', (e) ->
-      id = $(this).attr('data-id')
+      id = $(this).data('id')
       $("[data-id=#{id}]").toggleClass('target')
       key = $(this).parents('.page:first').data('key')
       $('.page').trigger('align-item', {key, id})


### PR DESCRIPTION
Actions now trigger an event on hover that alerts other pages that items they might hold are of interest to the user. The current action is for other pages that hold the item to scroll to center the item in the view.

This commit introduces the 'align-item' event described further in [plugins.fed.wiki.org](http://plugins.fed.wiki.org/view/well-known-events/view/item-alignment-events).

Curiously half of the necessary code has existed in the codebase for over a year but had clearly never been debugged.
