### PR TITLE
render page with flag linking site/slug

### DIFF
--- a/lib/page.coffee
+++ b/lib/page.coffee
@@ -116,6 +116,17 @@ newPage = (json, site) ->
   become = (template) ->
     page.story = template?.getRawPage().story || []
 
-  {getRawPage, getContext, isPlugin, isRemote, isLocal, getRemoteSite, getRemoteSiteDetails, getSlug, getNeighbors, getTitle, setTitle, getRevision, getTimestamp, addItem, addParagraph, seqItems, seqActions, become}
+  siteLineup = ->
+    slug = getSlug()
+    path = if slug == 'welcome-visitors'
+      "view/welcome-visitors"
+    else
+      "view/welcome-visitors/view/#{slug}"
+    if isRemote()
+      "//#{site}/#{path}"
+    else
+      "/#{path}"
+
+  {getRawPage, getContext, isPlugin, isRemote, isLocal, getRemoteSite, getRemoteSiteDetails, getSlug, getNeighbors, getTitle, setTitle, getRevision, getTimestamp, addItem, addParagraph, seqItems, seqActions, become, siteLineup}
 
 module.exports = {newPage, asSlug}

--- a/lib/refresh.coffee
+++ b/lib/refresh.coffee
@@ -108,7 +108,7 @@ emitHeader = ($header, $page, pageObject) ->
   tooltip = pageObject.getRemoteSiteDetails location.host
   $header.append """
     <h1 title="#{tooltip}">
-      <a href="//#{remote}">
+      <a href="#{pageObject.siteLineup()}">
         <img src="//#{remote}/favicon.png" height="32px" class="favicon">
       </a> #{pageObject.getTitle()}
     </h1>

--- a/test/page.coffee
+++ b/test/page.coffee
@@ -73,6 +73,20 @@ describe 'page', ->
       pageObject = newPage {}, 'sfw.c2.com'
       expect(pageObject.getRemoteSite('fed.wiki.org')).to.be 'sfw.c2.com'
 
+  describe 'site lineup', ->
+
+    it 'should start with welcome-visitors', ->
+      pageObject = newPage {title: "Welcome Visitors"}
+      expect(pageObject.siteLineup()).to.be '/view/welcome-visitors'
+
+    it 'should end on this page', ->
+      pageObject = newPage {title: "Some Page"}
+      expect(pageObject.siteLineup()).to.be '/view/welcome-visitors/view/some-page'
+
+    it 'should use absolute address for remote pages', ->
+      pageObject = newPage {title: "Some Page"}, 'fed.wiki.org'
+      expect(pageObject.siteLineup()).to.be '//fed.wiki.org/view/welcome-visitors/view/some-page'
+
   describe 'site details', ->
 
     it 'should report residence only if local', ->


### PR DESCRIPTION
This makes drag-and-drop work since lib/drop.coffee
can make sense of the link when dropped.

https://github.com/fedwiki/wiki-client/commit/7bad88c1cdf3e292c1cca4f4d31d03f0725f3820#commitcomment-6591648
