### PR TITLE
include page json when posting fork actions

### DIFF
--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -114,14 +114,16 @@ $ ->
 
     .delegate '.fork-page', 'click', (e) ->
       $page = $(e.target).parents('.page')
+      pageObject = lineup.atKey $page.data('key')
+      action = {type: 'fork', item: pageObject.getRawPage()}
       if $page.hasClass('local')
         unless pageHandler.useLocalStorage()
-          item = lineup.atKey($page.data('key')).getRawPage()
           $page.removeClass('local')
-          pageHandler.put $page, {type: 'fork', item} # push
+          pageHandler.put $page, action
       else
-        if (remoteSite = $page.data('site'))?
-          pageHandler.put $page, {type:'fork', site: remoteSite} # pull
+        if pageObject.isRemote()
+          action.site = pageObject.getRemoteSite()
+          pageHandler.put $page, action
 
     .delegate '.action', 'hover', (e) ->
       id = $(this).data('id')


### PR DESCRIPTION
This change allows us to fork a page from
behind a firewall to an origin server outside
that firewall. Both the ruby and node servers
have had support for this for a long time.

https://github.com/fedwiki/wiki-node-server/blob/master/lib/server.coffee#L476-L479
https://github.com/fedwiki/wiki-gem/blob/master/lib/wiki/server.rb#L245-L247
