### PR TITLE
Update regex for youtube videos.

### DIFF
--- a/lib/drop.coffee
+++ b/lib/drop.coffee
@@ -23,11 +23,11 @@ isPage = (url) ->
   null
 
 isVideo = (url) ->
-  if found = url.match /^https?:\/\/www.youtube.com\/watch\?v=([a-zA-Z0-9]+).*$/
+  if found = url.match /^https?:\/\/www.youtube.com\/watch\?v=([\w\-]+).*$/
     return {text: "YOUTUBE #{found[1]}"}
-  if found = url.match /^https?:\/\/youtu.be\/([a-zA-Z0-9]+).*$/
+  if found = url.match /^https?:\/\/youtu.be\/([\w\-]+).*$/
     return {text: "YOUTUBE #{found[1]}"}
-  if found = url.match /www.youtube.com%2Fwatch%3Fv%3D([a-zA-Z0-9]+).*$/
+  if found = url.match /www.youtube.com%2Fwatch%3Fv%3D([\w\-]+).*$/
     return {text: "YOUTUBE #{found[1]}"}
   if found = url.match /^https?:\/\/vimeo.com\/([0-9]+).*$/
     return {text: "VIMEO #{found[1]}"}


### PR DESCRIPTION
Video identifier can also include '-' and '_'.

Related to fedwiki/wiki-plugin-video#2, thanks to @michaelarthurcaulfield for identifying the deficiency in the plug-in.

This also raises a question, why is the drop code here rather than being included here from the plug-in?
