### PR TITLE
Add date to implicit forks. Remove destructive dom plundering.

### DIFF
--- a/lib/pageHandler.coffee
+++ b/lib/pageHandler.coffee
@@ -112,9 +112,8 @@ pushToLocal = ($page, pagePutInfo, action) ->
     page ||= lineup.atKey($page.data('key')).getRawPage()
     page.journal = [] unless page.journal?
     if (site=action['fork'])?
-      page.journal = page.journal.concat({'type':'fork','site':site})
+      page.journal = page.journal.concat({'type':'fork','site':site,'date':(new Date()).getTime()})
       delete action['fork']
-    page.story = $($page).find(".item").map(-> $(@).data("item")).get()
   page.journal = page.journal.concat(action)
   localStorage[pagePutInfo.slug] = JSON.stringify(page)
   addToJournal $page.find('.journal'), action


### PR DESCRIPTION
This request adds a date to implicit forks written to browser local storage.
This handles one case mentioned in https://github.com/WardCunningham/Smallest-Federated-Wiki/issues/431.

This request also removes a line of unwanted dom plundering for story items which has been made unnecessary by the reference to the `lineup` a few lines above. In fact this dom plundering only worked in the case where the dom annotations were current with edits and this was only true when the page was always edited in local storage. This stopped being true when we switch to local storage on ajax error. This corrects the "unreliability" casually mentioned in #50.
