### PR TITLE
compare lineup activities

### DIFF
--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -170,8 +170,8 @@ $ ->
       refresh.emitTwins $(element)
 
   lineupActivity = require './lineupActivity'
-  $("<span class=menu> &nbsp; &equiv;  &nbsp; </span>")
-    .css({"cursor":"pointer"})
+  $("<span class=menu> &nbsp; &equiv; &nbsp; </span>")
+    .css({"cursor":"pointer", "font-size": "120%"})
     .appendTo('footer')
     .click ->
       dialog.open "Lineup Activity", lineupActivity.show()

--- a/lib/lineupActivity.coffee
+++ b/lib/lineupActivity.coffee
@@ -12,7 +12,7 @@ activity = (journal, from, to) ->
 sparks = (journal) ->
   line = ''
   to = (new Date).getTime()
-  for i in [1..60]
+  for [1..60]
     line += if activity(journal, to-day, to) then '|' else '.'
     line += '<td>' if (new Date(to)).getDay() == 0
     to -= day


### PR DESCRIPTION
This commit creates a footer link to a feature that compares activity read from the journals of all pages in the lineup. This is a variation on recent changes that is more focused and sees all changes (up to 60 days) not just the most recent.

![screen shot 2014-09-21 at 1 49 39 pm](https://cloud.githubusercontent.com/assets/12127/4350057/b94c7c8c-41d3-11e4-99a3-74a624a56622.png)

This result was created by dragging pages from other open tabs into one tab and then invoking the `lineup activity` from the footer icon.

It might be appropriate to offer other features from this icon. For that reason I've chosen the "hamburger" icon that has become popular for offering lists of features.
