### PR TITLE
more video services recognized on drop

### DIFF
--- a/lib/drop.coffee
+++ b/lib/drop.coffee
@@ -31,8 +31,14 @@ isVideo = (url) ->
     return {text: "YOUTUBE #{found[1]}"}
   if found = url.match /^https?:\/\/vimeo.com\/([0-9]+).*$/
     return {text: "VIMEO #{found[1]}"}
-  if found = url.match /url=http%3A%2F%2Fvimeo.com%2F([0-9]+).*$/
+  if found = url.match /url=https?%3A%2F%2Fvimeo.com%2F([0-9]+).*$/
     return {text: "VIMEO #{found[1]}"}
+  if found = url.match /https?:\/\/archive.org\/details\/([\w\.\-]+).*$/
+    return {text: "ARCHIVE #{found[1]}"}
+  if found = url.match /https?:\/\/tedxtalks.ted.com\/video\/([\w\-]+).*$/
+    return {text: "TEDX #{found[1]}"}
+  if found = url.match /https?:\/\/www.ted.com\/talks\/([\w\.\-]+).*$/
+    return {text: "TED #{found[1]}"}
   null
 
 dispatch = (handlers) ->


### PR DESCRIPTION
Add regex for videos from Internet Archive and TED talks. 

Criteria for inclusion is support for an embed code and some sense of familiarity. Also need a companion update to the Video plugin. This is our companion pull request: https://github.com/fedwiki/wiki-plugin-video/pull/4. Synchronized deployment is not strictly required.
