### PR TITLE
record responseText when ajax error causes fork to local

### DIFF
--- a/lib/pageHandler.coffee
+++ b/lib/pageHandler.coffee
@@ -139,8 +139,7 @@ pushToServer = ($page, pagePutInfo, action) ->
       if action.type == 'fork' # push
         localStorage.removeItem $page.attr('id')
     error: (xhr, type, msg) ->
-      console.log "pageHandler.put ajax error callback", type, msg
-      action.error = {type, msg}
+      action.error = {type, msg, response: xhr.responseText}
       pushToLocal $page, pagePutInfo, action
 
 pageHandler.put = ($page, action) ->


### PR DESCRIPTION
This change logs responseText in a Journal Action if that action can't be completed by the server due to some server error. This would included the text argument to a server-side throw.

The desirability of this logging was observed during recent testing.
https://github.com/fedwiki/wiki-node-server/pull/79#issuecomment-64143450
