### PR TITLE
square bracket syntax does not work if slug is a keyword

### DIFF
--- a/lib/pageHandler.coffee
+++ b/lib/pageHandler.coffee
@@ -115,7 +115,7 @@ pushToLocal = ($page, pagePutInfo, action) ->
       page.journal = page.journal.concat({'type':'fork','site':site,'date':(new Date()).getTime()})
       delete action['fork']
   revision.apply page, action
-  localStorage[pagePutInfo.slug] = JSON.stringify(page)
+  localStorage.setItem(pagePutInfo.slug, JSON.stringify(page))
   addToJournal $page.find('.journal'), action
   $page.addClass("local")
 


### PR DESCRIPTION
A probable fix for WardCunningham/Smallest-Federated-Wiki#438

If slug is a keyword, such as clear, the bracket syntax acts on the keyword rather than looking for the page in localStorage. 

Attempting to load a page called clear will clear local storage!!!
