### PR TITLE
fix incorrect duplications in revisions

### DIFF
--- a/lib/revision.coffee
+++ b/lib/revision.coffee
@@ -21,7 +21,7 @@ apply = (page, action) ->
     when 'create'
       if action.item?
         page.title = action.item.title if action.item.title?
-        page.story = action.item.story if action.item.story?
+        page.story = action.item.story.slice() if action.item.story?
     when 'add'
       add action.after, action.item
     when 'edit'


### PR DESCRIPTION
An unwanted shared array lead to unwanted duplication of story items when reconstructed from the journal.

This is a safe fix to a bad bug.
