### PR TITLE
ignore forks when figuring date for twins

### DIFF
--- a/lib/refresh.coffee
+++ b/lib/refresh.coffee
@@ -164,14 +164,18 @@ emitFooter = ($footer, pageObject) ->
     <a href= "//#{host}/#{slug}.html">#{host}</a>
   """
 
+editDate = (journal) ->
+  for action in (journal || []) by -1
+    return action.date if action.date and action.type != 'fork'
+  undefined
+
 emitTwins = ($page) ->
   page = $page.data 'data'
   return unless page
   site = $page.data('site') or window.location.host
   site = window.location.host if site in ['view', 'origin']
   slug = asSlug page.title
-  if (actions = page.journal?.length)? and (viewing = page.journal[actions-1]?.date)?
-    viewing = Math.floor(viewing/1000)*1000
+  if viewing = editDate(page.journal)
     bins = {newer:[], same:[], older:[]}
     # {fed.wiki.org: [{slug: "happenings", title: "Happenings", date: 1358975303000, synopsis: "Changes here ..."}]}
     for remoteSite, info of neighborhood.sites


### PR DESCRIPTION
This is a companion to https://github.com/fedwiki/wiki-node-server/pull/82
The two pull requests can be merged in either order.

This makes sure the same editDate methodology is applied to a page in the lineup as those discovered in the sitemap. This causes forked pages to fall into the 'same' bin.
See also http://forage.ward.fed.wiki.org/broadcast-workflow.html

![image](https://cloud.githubusercontent.com/assets/12127/5430791/8892d2b2-83cd-11e4-9d15-bfc53bbd6717.png)
