### PR TITLE
Ward/fork from history

### DIFF
--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -123,7 +123,7 @@ $ ->
       else if pageObject.isRemote()
         action.site = pageObject.getRemoteSite()
         pageHandler.put $page, action
-      else if $page.data('rev')
+      else if $page.data('rev')?
         $page.removeClass('ghost')
         $page.find('.revision').remove()
         pageHandler.put $page, action

--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -117,16 +117,13 @@ $ ->
       pageObject = lineup.atKey $page.data('key')
       action = {type: 'fork'}
       if $page.hasClass('local')
-        unless pageHandler.useLocalStorage()
-          $page.removeClass('local')
-          pageHandler.put $page, action
+        return if pageHandler.useLocalStorage()
       else if pageObject.isRemote()
         action.site = pageObject.getRemoteSite()
-        pageHandler.put $page, action
-      else if $page.data('rev')?
+      if $page.data('rev')?
         $page.removeClass('ghost')
         $page.find('.revision').remove()
-        pageHandler.put $page, action
+      pageHandler.put $page, action
 
     .delegate '.action', 'hover', (e) ->
       id = $(this).data('id')

--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -118,6 +118,7 @@ $ ->
       action = {type: 'fork'}
       if $page.hasClass('local')
         return if pageHandler.useLocalStorage()
+        $page.removeClass('local')
       else if pageObject.isRemote()
         action.site = pageObject.getRemoteSite()
       if $page.data('rev')?

--- a/lib/pageHandler.coffee
+++ b/lib/pageHandler.coffee
@@ -179,6 +179,7 @@ pageHandler.put = ($page, action) ->
   # update dom when forking
   if forkFrom
     # pull remote site closer to us
+    $page.find('h1').prop('title',location.host)
     $page.find('h1 img').attr('src', '/favicon.png')
     $page.find('h1 a').attr('href', '/')
     $page.data('site', null)


### PR DESCRIPTION
Now that we can fork prior versions we find that there are cases we hadn't considered. With these commits we can fork from a remote page's history and as well as to and from browser local storage.

Since we can find that forking changes multiple properties of a page we need to organize the update of those properties as a series of if-statements where multiple then-clauses can apply. Previously we used else-if clauses under the assumption that only one thing was changing.