### PR TITLE
try harder to find a reference slug

### DIFF
--- a/lib/reference.coffee
+++ b/lib/reference.coffee
@@ -5,11 +5,14 @@
 
 editor = require './editor'
 resolve = require './resolve'
+page = require './page'
 
 # see http://fed.wiki.org/about-reference-plugin.html
 
 emit = ($item, item) ->
-  slug = item.slug or 'welcome-visitors'
+  slug = item.slug
+  slug ||= page.asSlug item.title if item.title?
+  slug ||= 'welcome-visitors'
   site = item.site
   resolve.resolveFrom site, ->
     $item.append """


### PR DESCRIPTION
I've seen reference items send users to welcome-visitors. This is the default if the reference doesn't have a slug for the referenced page. I don't know when this started happening but I'm seeing lots of references without slugs. Perhaps the revision to the drop logic let this one slip in.

I've added a fall-back to making the slug from the title if title is present. This restores the desired behavior if by an alternate means. I'm deep in another set of commits or I would track down the root cause.

