### PR TITLE
Improved html escapes now handled by resolveLinks

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -74,6 +74,7 @@ module.exports = function (grunt) {
           'test/lineup.coffee',
           'test/drop.coffee',
           'test/revision.coffee',
+          'test/resolve.coffee',
           'test/wiki.coffee'
         ]
       }

--- a/lib/editor.coffee
+++ b/lib/editor.coffee
@@ -18,6 +18,12 @@ random = require './random'
 #   after: id -- new item to be added after id
 #   sufix: text -- editor opens with unsaved suffix appended
 
+escape = (string) ->
+  string
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+
 textEditor = ($item, item, option={}) ->
   console.log 'textEditor', item.id, option
 
@@ -85,7 +91,7 @@ textEditor = ($item, item, option={}) ->
   $item.addClass 'textEditing'
   $item.unbind()
   original = item.text ? ''
-  $textarea = $("<textarea>#{original}#{option.suffix ? ''}</textarea>")
+  $textarea = $("<textarea>#{escape original}#{escape option.suffix ? ''}</textarea>")
     .focusout focusoutHandler
     .bind 'keydown', keydownHandler
   $item.html $textarea

--- a/lib/paragraph.coffee
+++ b/lib/paragraph.coffee
@@ -6,13 +6,9 @@ editor = require './editor'
 resolve = require './resolve'
 itemz = require './itemz'
 
-# http://jsperf.com/encode-html-entities
-safe = (str) ->
-  str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-
 emit = ($item, item) ->
   for text in item.text.split /\n\n+/
-    $item.append "<p>#{resolve.resolveLinks(safe text)}</p>" if text.match /\S/
+    $item.append "<p>#{resolve.resolveLinks(text)}</p>" if text.match /\S/
 
 bind = ($item, item) ->
   $item.dblclick (e) ->

--- a/lib/reference.coffee
+++ b/lib/reference.coffee
@@ -5,11 +5,14 @@
 
 editor = require './editor'
 resolve = require './resolve'
+page = require './page'
 
 # see http://fed.wiki.org/about-reference-plugin.html
 
 emit = ($item, item) ->
-  slug = item.slug or 'welcome-visitors'
+  slug = item.slug
+  slug ||= page.asSlug item.title if item.title?
+  slug ||= 'welcome-visitors'
   site = item.site
   resolve.resolveFrom site, ->
     $item.append """

--- a/lib/refresh.coffee
+++ b/lib/refresh.coffee
@@ -130,7 +130,7 @@ emitHeader = ($header, $page, pageObject) ->
     <h1 title="#{tooltip}">
       <a href="#{pageObject.siteLineup()}">
         <img src="//#{remote}/favicon.png" height="32px" class="favicon">
-      </a> #{pageObject.getTitle()}
+      </a> #{resolve.escape pageObject.getTitle()}
     </h1>
   """
   $header.find('a').on 'click', handleHeaderClick

--- a/lib/resolve.coffee
+++ b/lib/resolve.coffee
@@ -8,7 +8,7 @@ module.exports = resolve = {}
 
 resolve.resolutionContext = []
 
-escape = (string) ->
+resolve.escape = escape = (string) ->
   string
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')

--- a/lib/resolve.coffee
+++ b/lib/resolve.coffee
@@ -8,6 +8,12 @@ module.exports = resolve = {}
 
 resolve.resolutionContext = []
 
+escape = (string) ->
+  string
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+
 resolve.resolveFrom = (addition, callback) ->
   resolve.resolutionContext.push addition
   try
@@ -15,13 +21,39 @@ resolve.resolveFrom = (addition, callback) ->
   finally
     resolve.resolutionContext.pop()
 
-resolve.resolveLinks = (string) ->
-  renderInternalLink = (match, name) ->
-    # spaces become 'slugs', non-alpha-num get removed
+# resolveLinks takes a second argument which is a substitute text sanitizer.
+# Plugins that do their own markup should insert themselves here but they
+# must escape html as part of their processing. Sanitizers must pass markers〖12〗.
+
+resolve.resolveLinks = (string, sanitize=escape) ->
+  stashed = []
+
+  stash = (text) ->
+    here = stashed.length
+    stashed.push text
+    "〖#{here}〗"
+
+  unstash = (match, digits) ->
+    stashed[+digits]
+
+  internal = (match, name) ->
     slug = asSlug name
-    "<a class=\"internal\" href=\"/#{slug}.html\" data-page-name=\"#{slug}\" title=\"#{resolve.resolutionContext.join(' => ')}\">#{name}</a>"
-  string
-    .replace(/\[\[([^\]]+)\]\]/gi, renderInternalLink)
-    .replace(/\[((http|https|ftp):.*?) (.*?)\]/gi, """<a class="external" target="_blank" href="$1" title="$1" rel="nofollow">$3 <img src="/images/external-link-ltr-icon.png"></a>""")
+    stash """<a class="internal" href="/#{slug}.html" data-page-name="#{slug}" title="#{resolve.resolutionContext.join(' => ')}">#{escape name}</a>"""
+
+  external = (match, href, protocol, rest) ->
+    stash """<a class="external" target="_blank" href="#{href}" title="#{href}" rel="nofollow">#{escape rest} <img src="/images/external-link-ltr-icon.png"></a>"""
+
+  # markup conversion happens in four phases:
+  #   - unexpected markers are adulterated
+  #   - links are found, converted, and stashed away properly escaped
+  #   - remaining text is sanitized and/or escaped
+  #   - unique markers are replaced with unstashed links
+
+  string = string
+    .replace /〖(\d+)〗/g, "〖 $1 〗"
+    .replace /\[\[([^\]]+)\]\]/gi, internal
+    .replace /\[((http|https|ftp):.*?) (.*?)\]/gi, external
+  sanitize string
+    .replace /〖(\d+)〗/g, unstash
 
 

--- a/test/resolve.coffee
+++ b/test/resolve.coffee
@@ -1,0 +1,50 @@
+resolve = require('../lib/resolve')
+expect = require 'expect.js'
+
+# Here we test new features retlated to escaping/sanitizing text while resolving.
+# See other related tests at /tests/wiki.coffee
+
+r = (text) -> resolve.resolveLinks text
+
+f = (text) ->
+  found = []
+  text
+    .replace /\s+<img src="\/images\/external-link-ltr-icon.png">/, ''
+    .replace />(.*?)</g, (match, each) -> found.push each
+  found
+
+describe 'resolve', ->
+
+  describe 'plain text', ->
+    it 'should pass unchanged', ->
+      expect(r 'The quick brown fox.').to.eql 'The quick brown fox.'
+
+  describe 'escaping', ->
+    it 'should encode <, >, & in plain text', ->
+      expect(r '5 < 10 && 5 > 3').to.eql '5 &lt; 10 &amp;&amp; 5 &gt; 3'
+
+    it 'should encode  <, >, & in link text', ->
+      expect(r '[[5 < 10 && 5 > 3]]').to.contain '>5 &lt; 10 &amp;&amp; 5 &gt; 3</a>'
+
+    it 'should not encode before making slugs for hrefs', ->
+      expect(r '[[5 < 10 && 5 > 3]]').to.contain 'href="/5--10--5--3.html"'
+
+    it 'should not encode before making slugs for data-page-names', ->
+      expect(r '[[5 < 10 && 5 > 3]]').to.contain 'data-page-name="5--10--5--3"'
+
+  describe 'multiple links', ->
+    it 'should be kept ordered', ->
+      expect(f r '[[alpha]],[[beta]]&[[gamma]]').to.eql ['alpha', ',', 'beta', '&amp;', 'gamma']
+
+    it 'should preserve internal before external', ->
+      expect(f r '[[alpha]],[http:c2.com beta]').to.eql ['alpha', ',', 'beta']
+
+    it 'should preserve external before internal', ->
+      expect(f r '[http:c2.com beta],[[alpha]]').to.eql ['beta', ',', 'alpha']
+
+  describe 'markers', ->
+    it 'should be adulterated where unexpected', ->
+      expect(r 'foo 〖12〗 bar').to.eql "foo 〖 12 〗 bar"
+
+
+


### PR DESCRIPTION
These commits improve html escapes as suggested in issue #80.
(Somehow I've picked up an independent commit appearing in a separate pull request.)

We combine resolving links with escaping html. The link resolution happens in two steps with the html escaping occurring between them. This is the comment from the relevant code.

```
  # markup conversion happens in four phases:
  #   - unexpected markers are adulterated
  #   - links are found, converted, and stashed away properly escaped
  #   - remaining text is sanitized and/or escaped
  #   - unique markers are replaced with unstashed links
```
The resolveLinks call now takes a second parameter where one might provide an alternative to simple html escaping. Alternative markup plugins will use this to offer their alternative translation method. The method provided must be secure in that it must effectively escape in addition to what ever else it does. There will be companion pull requests to these plugins that should be released together.

We also escape the page title text. This is step two of closing the xss vulnerability. We should audit every place we render any text from remote json and ensure appropriate escapes are in place.