### PR TITLE
Ward/prompts

### DIFF
--- a/lib/editor.coffee
+++ b/lib/editor.coffee
@@ -17,6 +17,7 @@ random = require './random'
 #   append: true -- sets the cursor to end and scrolls there
 #   after: id -- new item to be added after id
 #   sufix: text -- editor opens with unsaved suffix appended
+#   field: 'text' -- editor operates on this field of the item
 
 escape = (string) ->
   string
@@ -47,7 +48,7 @@ textEditor = ($item, item, option={}) ->
         $previous = $item.prev()
         previous = itemz.getItem $previous
         return false unless previous.type is 'paragraph'
-        caret = previous.text.length
+        caret = previous[option.field||'text'].length
         suffix = $textarea.val()
         $textarea.val('') # Need current text area to be empty. Item then gets deleted.
         textEditor $previous, previous, {caret, suffix}
@@ -73,13 +74,13 @@ textEditor = ($item, item, option={}) ->
     $item.removeClass 'textEditing'
     $textarea.unbind()
     $page = $item.parents('.page:first')
-    if item.text = $textarea.val()
+    if item[option.field||'text'] = $textarea.val()
       plugin.do $item.empty(), item
       if option.after
-        return if item.text == ''
+        return if item[option.field||'text'] == ''
         pageHandler.put $page, {type: 'add', id: item.id, item: item, after: option.after}
       else
-        return if item.text == original
+        return if item[option.field||'text'] == original
         pageHandler.put $page, {type: 'edit', id: item.id, item: item}
     else
       unless option.after
@@ -90,7 +91,7 @@ textEditor = ($item, item, option={}) ->
   return if $item.hasClass 'textEditing'
   $item.addClass 'textEditing'
   $item.unbind()
-  original = item.text ? ''
+  original = item[option.field||'text'] ? ''
   $textarea = $("<textarea>#{escape original}#{escape option.suffix ? ''}</textarea>")
     .focusout focusoutHandler
     .bind 'keydown', keydownHandler

--- a/lib/factory.coffee
+++ b/lib/factory.coffee
@@ -10,6 +10,14 @@ editor = require './editor'
 synopsis = require './synopsis'
 drop = require './drop'
 
+escape = (line) ->
+  line
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/\n/g, '<br>')
+
+
 emit = ($item, item) ->
   $item.append '<p>Double-Click to Edit<br>Drop Text or Image to Insert</p>'
 
@@ -32,7 +40,7 @@ emit = ($item, item) ->
       editor.textEditor $item, item
 
   showPrompt = ->
-    $item.append "<p>#{resolve.resolveLinks(item.prompt)}</b>"
+    $item.append "<p>#{resolve.resolveLinks(item.prompt, escape)}</b>"
 
   if item.prompt
     showPrompt()
@@ -60,7 +68,7 @@ bind = ($item, item) ->
     pageHandler.put $page, {type: 'edit', id: item.id, item: item}
 
   punt = (data) ->
-    item.prompt = "<b>Unexpected Item</b><br>We can't make sense of the drop.<br>#{JSON.stringify data}<br>Try something else or see [[About Factory Plugin]]."
+    item.prompt = "Unexpected Item\nWe can't make sense of the drop.\nTry something else or see [[About Factory Plugin]]."
     data.userAgent = navigator.userAgent
     item.punt = data
     syncEditAction()
@@ -108,10 +116,13 @@ bind = ($item, item) ->
         punt
           file: file
 
-  $item.dblclick ->
-    $item.removeClass('factory').addClass(item.type='paragraph')
-    $item.unbind()
-    editor.textEditor $item, item
+  $item.dblclick (e) ->
+    if e.shiftKey
+      editor.textEditor $item, item, {field: 'prompt'}
+    else
+      $item.removeClass('factory').addClass(item.type = 'paragraph')
+      $item.unbind()
+      editor.textEditor $item, item
 
   $item.bind 'dragenter', (evt) -> evt.preventDefault()
   $item.bind 'dragover', (evt) -> evt.preventDefault()


### PR DESCRIPTION
The factory has a little used prompt field which can guide users to enter the proper thing.
This commit makes this property easily editable. Shift-double-click to edit the prompt.
This commit also adds an option to the textEditor that allows one to specify what field is being edited.