### PR TITLE
save true item.id as item.alias to avoid duplicates

### DIFF
--- a/lib/page.coffee
+++ b/lib/page.coffee
@@ -92,6 +92,11 @@ newPage = (json, site) ->
     item = _.extend {}, {id: random.itemId()}, item
     page.story.push item
 
+  getItem = (id) ->
+    for item in page.story
+      return item if item.id is id
+    return null
+
   seqItems = (each) ->
     emitItem = (i) ->
       return if i >= page.story.length
@@ -153,6 +158,6 @@ newPage = (json, site) ->
     revision.apply page, action
     site = null if action.site
 
-  {getRawPage, getContext, isPlugin, isRemote, isLocal, getRemoteSite, getRemoteSiteDetails, getSlug, getNeighbors, getTitle, setTitle, getRevision, getTimestamp, addItem, addParagraph, seqItems, seqActions, become, siteLineup, merge, apply}
+  {getRawPage, getContext, isPlugin, isRemote, isLocal, getRemoteSite, getRemoteSiteDetails, getSlug, getNeighbors, getTitle, setTitle, getRevision, getTimestamp, addItem, getItem, addParagraph, seqItems, seqActions, become, siteLineup, merge, apply}
 
 module.exports = {newPage, asSlug, pageEmitter}

--- a/lib/refresh.coffee
+++ b/lib/refresh.coffee
@@ -33,6 +33,20 @@ pageEmitter = pageModule.pageEmitter
 getItem = ($item) ->
   $($item).data("item") or $($item).data('staticItem') if $($item).length > 0
 
+aliasItem = ($page, $item, oldItem) ->
+  item = $.extend {}, oldItem
+  pageObject = lineup.atKey($page.data('key'))
+  if pageObject.getItem(item.id)?
+    item.alias ||= item.id
+    item.id = random.itemId()
+    $item.attr 'data-id', item.id
+  else if item.alias?
+    unless pageObject.getItem(item.alias)?
+      item.id = item.alias
+      delete item.alias
+      $item.attr 'data-id', item.id
+  item
+
 handleDragging = (evt, ui) ->
   $item = ui.item
 
@@ -66,7 +80,8 @@ handleDragging = (evt, ui) ->
     $item.data 'pageElement', $thisPage
     $before = $item.prev('.item')
     before = getItem($before)
-    {type: 'add', item: item, after: before?.id}
+    item = aliasItem $thisPage, $item, item
+    {type: 'add', item, after: before?.id}
   action.id = item.id
   pageHandler.put $thisPage, action
 


### PR DESCRIPTION
This commit adds logic to the item drop handler to assign a new id to any item that conflicts with any existing item with the same id. This conflict happens when dragging multiple copies of an item into a single page.

This can happen when pulling items out of history. You can keep recalling the item from history and keep pulling the recalled item on to the same page. Move depends on unique ids and probably other things too.

The original id will be restored if the aliased item is subsequently dragged to a page without id conflict.

Journal merge will have to deal with similar aliasing if it is to be reliable.

Items that have been aliased store their original id in a field named 'alias'. Yes, I know this is counter intuitive.