### PR TITLE
Improved put logic makes editing in localStorage viable.

### DIFF
--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -149,7 +149,6 @@ $ ->
       pageObject = lineup.atKey $page.data('key')
       action = {type: 'fork'}
       if $page.hasClass('local')
-        return if pageHandler.useLocalStorage()
         $page.removeClass('local')
       else if pageObject.isRemote()
         action.site = pageObject.getRemoteSite()

--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -72,14 +72,24 @@ $ ->
     console.log $page.find('.item').map((i,e)->$(e).data('item').type).toArray()
     console.log '---- lineup ---------------------------'
     console.log $page.data('key')
-    console.log (item.id for item in lineup.atKey($page.data('key')).getRawPage().story)
-    console.log (item.type for item in lineup.atKey($page.data('key')).getRawPage().story)
+    pageObject = lineup.atKey($page.data('key'))
+    slug = pageObject.getSlug()
+    console.log slug
+    console.log 'local' if pageObject.isLocal()
+    console.log 'plugin' if pageObject.isPlugin()
+    console.log pageObject.getRemoteSite() if pageObject.isRemote()
+    console.log (item.id for item in pageObject.getRawPage().story)
+    console.log (item.type for item in pageObject.getRawPage().story)
     if json = localStorage.getItem(slug)
       console.log '---- localStorage ---------------------'
       page = JSON.parse(json)
       console.log (item.id for item in page.story)
       console.log (item.type for item in page.story)
-    console.log '---------------------------------------'
+    $.getJSON "http:/#{slug}.json", (page) ->
+      console.log '---- server ---------------------------'
+      console.log (item.id for item in page.story)
+      console.log (item.type for item in page.story)
+      console.log '---------------------------------------'
 
   $('.main')
     .delegate '.show-page-source', 'click', (e) ->

--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -62,6 +62,25 @@ $ ->
     link.doInternalLink name, page, $(e.target).data('site')
     return false
 
+  pageDump = (element) ->
+    $page = $(element)
+    slug = element.id
+    console.log '---- dom ------------------------------'
+    console.log slug
+    console.log element
+    console.log $page.find('.item').map((i,e)->$(e).data('id')).toArray()
+    console.log $page.find('.item').map((i,e)->$(e).data('item').type).toArray()
+    console.log '---- lineup ---------------------------'
+    console.log $page.data('key')
+    console.log (item.id for item in lineup.atKey($page.data('key')).getRawPage().story)
+    console.log (item.type for item in lineup.atKey($page.data('key')).getRawPage().story)
+    if json = localStorage.getItem(slug)
+      console.log '---- localStorage ---------------------'
+      page = JSON.parse(json)
+      console.log (item.id for item in page.story)
+      console.log (item.type for item in page.story)
+    console.log '---------------------------------------'
+
   $('.main')
     .delegate '.show-page-source', 'click', (e) ->
       e.preventDefault()
@@ -71,6 +90,9 @@ $ ->
 
     .delegate '.page', 'click', (e) ->
       active.set this unless $(e.target).is("a")
+
+    .delegate '.page', 'dblclick', (e) ->
+      pageDump this if $(e.target).is('.page')
 
     .delegate '.internal', 'click', (e) ->
       name = $(e.target).data 'pageName'

--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -148,6 +148,12 @@ $ ->
         $page.find('.revision').remove()
       pageHandler.put $page, action
 
+    .delegate '.add-factory', 'click', (e) ->
+      e.preventDefault()
+      $page = $(e.target).parents('.page')
+      return if $page.hasClass 'ghost'
+      refresh.createFactory($page)
+
     .delegate '.action', 'hover', (e) ->
       id = $(this).data('id')
       $("[data-id=#{id}]").toggleClass('target')

--- a/lib/page.coffee
+++ b/lib/page.coffee
@@ -45,8 +45,8 @@ newPage = (json, site) ->
   isPlugin = ->
     page.plugin?
 
-  isRemote = ->
-    ! (site in [undefined, null, 'view', 'origin', 'local'])
+  isRemote = (host = null) ->
+    ! (site in [undefined, null, host, 'view', 'origin', 'local'])
 
   isLocal = ->
     site == 'local'
@@ -127,6 +127,9 @@ newPage = (json, site) ->
   become = (template) ->
     page.story = template?.getRawPage().story || []
 
+  becomeLocal = ->
+    site = 'local'
+
   siteLineup = ->
     slug = getSlug()
     path = if slug == 'welcome-visitors'
@@ -158,6 +161,6 @@ newPage = (json, site) ->
     revision.apply page, action
     site = null if action.site
 
-  {getRawPage, getContext, isPlugin, isRemote, isLocal, getRemoteSite, getRemoteSiteDetails, getSlug, getNeighbors, getTitle, setTitle, getRevision, getTimestamp, addItem, getItem, addParagraph, seqItems, seqActions, become, siteLineup, merge, apply}
+  {getRawPage, getContext, isPlugin, isRemote, isLocal, getRemoteSite, getRemoteSiteDetails, getSlug, getNeighbors, getTitle, setTitle, getRevision, getTimestamp, addItem, getItem, addParagraph, seqItems, seqActions, become, becomeLocal, siteLineup, merge, apply}
 
 module.exports = {newPage, asSlug, pageEmitter}

--- a/lib/refresh.coffee
+++ b/lib/refresh.coffee
@@ -327,4 +327,9 @@ cycle = ->
     whenNotGotten: createGhostPage
     pageInformation: pageInformation
 
+pageEmitter.on 'refresh', ($page) ->
+  pageObject = lineup.atKey($page.data('key'))
+  $page.empty()
+  rebuildPage pageObject, $page
+
 module.exports = {cycle, emitTwins, buildPage, rebuildPage, createFactory}

--- a/lib/refresh.coffee
+++ b/lib/refresh.coffee
@@ -113,12 +113,6 @@ initMerging = ($page) ->
     hoverClass: "ui-state-hover"
     drop: handleMerging
 
-initAddButton = ($page) ->
-  $page.find(".add-factory").live "click", (evt) ->
-    return if $page.hasClass 'ghost'
-    evt.preventDefault()
-    createFactory($page)
-
 createFactory = ($page) ->
   item =
     type: "factory"
@@ -272,7 +266,6 @@ rebuildPage = (pageObject, $page) ->
 
   initDragging $page
   initMerging $page
-  initAddButton $page
   $page
 
 buildPage = (pageObject, $page) ->
@@ -334,4 +327,4 @@ cycle = ->
     whenNotGotten: createGhostPage
     pageInformation: pageInformation
 
-module.exports = {cycle, emitTwins, buildPage, rebuildPage}
+module.exports = {cycle, emitTwins, buildPage, rebuildPage, createFactory}

--- a/lib/search.coffee
+++ b/lib/search.coffee
@@ -3,7 +3,6 @@
 # page to present them.
 
 link = require './link'
-active = require './active'
 newPage = require('./page').newPage
 
 createSearch = ({neighborhood})->


### PR DESCRIPTION
This pull request replaces the hopelessly convoluted incremental pageHandler.put logic that is engaged when a pages is automatically forked to local storage. This uses the newish pageObject as the trusted representation to be saved (the product of our core client refactoring) along with emitting a 'refresh' event that communicates from the bowels of storage to the user interface, the first that we've employed this long-sought approach.

With this we need not fear the "yellow halo of doom" as it has become known.

The previously serious deficiency is now replaced with several known inconveniences.
* The textEditor split logic is foiled by the 'refresh' and reverts to the same behavior as other item types.
* A shared memory bug causes some history loss in the journal with repeated edits.

We include a debugging utility that writes a summary of all four page representations to console.log upon a shift-double-click. These are dom, model, localStorage and server.