### PR TITLE
a single tab per origin

### DIFF
--- a/client.coffee
+++ b/client.coffee
@@ -1,5 +1,7 @@
+console.log "Window Name: " + window.name
+window.name = window.location.host
+
 window.wiki = require('./lib/wiki')
 require('./lib/legacy')
 require './lib/bind'
 require './lib/plugins'
-

--- a/lib/addToJournal.coffee
+++ b/lib/addToJournal.coffee
@@ -23,6 +23,6 @@ module.exports = ($journal, action) ->
     $action
       .css("background-image", "url(//#{action.site}/favicon.png)")
       .attr("href", "//#{action.site}/#{$page.attr('id')}.html")
+      .attr("target", "#{action.site}")
       .data("site", action.site)
       .data("slug", $page.attr('id'))
-

--- a/lib/refresh.coffee
+++ b/lib/refresh.coffee
@@ -144,6 +144,7 @@ emitHeader = ($header, $page, pageObject) ->
   $header.append """
     <h1 title="#{tooltip}">
       <a href="#{pageObject.siteLineup()}">
+      <a href="#{pageObject.siteLineup()}" target="#{remote}">
         <img src="//#{remote}/favicon.png" height="32px" class="favicon">
       </a> #{resolve.escape pageObject.getTitle()}
     </h1>

--- a/lib/refresh.coffee
+++ b/lib/refresh.coffee
@@ -177,7 +177,7 @@ emitFooter = ($footer, pageObject) ->
   $footer.append """
     <a id="license" href="http://creativecommons.org/licenses/by-sa/3.0/">CC BY-SA 3.0</a> .
     <a class="show-page-source" href="/#{slug}.json?random=#{random.randomBytes(4)}" title="source">JSON</a> .
-    <a href= "//#{host}/#{slug}.html">#{host}</a>
+    <a href= "//#{host}/#{slug}.html" target="#{host}">#{host} </a>
   """
 
 editDate = (journal) ->

--- a/lib/refresh.coffee
+++ b/lib/refresh.coffee
@@ -136,14 +136,16 @@ handleHeaderClick = (e) ->
     lineup.debugSelfCheck ($(each).data('key') for each in $('.page'))
     $page = $(e.target).parents('.page:first')
     crumbs = lineup.crumbs $page.data('key'), location.host
-    window.location = "//#{crumbs.join '/'}"
+    [target, ] = crumbs
+    newWindow = window.open "//#{crumbs.join '/'}", target
+    newWindow.focus
+
 
 emitHeader = ($header, $page, pageObject) ->
   remote = pageObject.getRemoteSite location.host
   tooltip = pageObject.getRemoteSiteDetails location.host
   $header.append """
     <h1 title="#{tooltip}">
-      <a href="#{pageObject.siteLineup()}">
       <a href="#{pageObject.siteLineup()}" target="#{remote}">
         <img src="//#{remote}/favicon.png" height="32px" class="favicon">
       </a> #{resolve.escape pageObject.getTitle()}

--- a/lib/refresh.coffee
+++ b/lib/refresh.coffee
@@ -138,7 +138,7 @@ handleHeaderClick = (e) ->
     crumbs = lineup.crumbs $page.data('key'), location.host
     [target, ] = crumbs
     newWindow = window.open "//#{crumbs.join '/'}", target
-    newWindow.focus
+    newWindow.focus()
 
 
 emitHeader = ($header, $page, pageObject) ->


### PR DESCRIPTION
This is a start of what we talked about in the hangout (Feb. 4th 2015).

Links and events that that would result in a change of origin will open in a new tab. We use the site name to name the tabs, so we can reuse tabs.

Works well in Chrome (and Vivaldi), but in Firefox the initial tab does not get reused correctly - suspect this is a browser feature.

While focus is switched, correctly in Chrome, it does not work correctly in Firefox if it configured to open new windows in a new tab.