### PR TITLE
Shift for hover effects on items and actions.

### DIFF
--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -11,6 +11,7 @@ lineup = require './lineup'
 drop = require './drop'
 dialog = require './dialog'
 link = require './link'
+target = require './target'
 
 asSlug = require('./page').asSlug
 
@@ -126,23 +127,6 @@ $ ->
         $page.find('.revision').remove()
       pageHandler.put $page, action
 
-    .delegate '.action', 'hover', (e) ->
-      if e.shiftKey
-        id = $(this).data('id')
-        $("[data-id=#{id}]").toggleClass('target')
-        key = $(this).parents('.page:first').data('key')
-        $('.page').trigger('align-item', {key, id})
-
-    .delegate '.item', 'hover', (e) ->
-      if e.shiftKey
-        id = $(this).attr('data-id')
-        $(".action[data-id=#{id}]").toggleClass('target')
-
-    $(document).keyup (e) ->
-        console.log 'keyup', e.keyCode
-        if e.keyCode = 16
-          $('.action').removeClass 'target'
-
     .delegate 'button.create', 'click', (e) ->
       getTemplate $(e.target).data('slug'), (template) ->
         $page = $(e.target).parents('.page:first')
@@ -152,14 +136,6 @@ $ ->
         page = pageObject.getRawPage()
         refresh.rebuildPage pageObject, $page.empty()
         pageHandler.put $page, {type: 'create', id: page.id, item: {title:page.title, story:page.story}}
-
-    .delegate '.page', 'align-item', (e, align) ->
-      $page = $(this)
-      return if $page.data('key') == align.key
-      $item = $page.find(".item[data-id=#{align.id}]")
-      return unless $item.length
-      position = $item.offset().top + $page.scrollTop() - $page.height()/2
-      $page.stop().animate {scrollTop: position}, 'slow'
 
     .delegate '.score', 'hover', (e) ->
       $('.main').trigger 'thumb', $(e.target).data('thumb')
@@ -183,6 +159,9 @@ $ ->
     .appendTo('footer')
     .click ->
       dialog.open "Lineup Activity", lineupActivity.show()
+
+  target.bind()
+
 
   $ ->
     state.first()

--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -127,14 +127,21 @@ $ ->
       pageHandler.put $page, action
 
     .delegate '.action', 'hover', (e) ->
-      id = $(this).data('id')
-      $("[data-id=#{id}]").toggleClass('target')
-      key = $(this).parents('.page:first').data('key')
-      $('.page').trigger('align-item', {key, id})
+      if e.shiftKey
+        id = $(this).data('id')
+        $("[data-id=#{id}]").toggleClass('target')
+        key = $(this).parents('.page:first').data('key')
+        $('.page').trigger('align-item', {key, id})
 
-    .delegate '.item', 'hover', ->
-      id = $(this).attr('data-id')
-      $(".action[data-id=#{id}]").toggleClass('target')
+    .delegate '.item', 'hover', (e) ->
+      if e.shiftKey
+        id = $(this).attr('data-id')
+        $(".action[data-id=#{id}]").toggleClass('target')
+
+    $(document).keyup (e) ->
+        console.log 'keyup', e.keyCode
+        if e.keyCode = 16
+          $('.action').removeClass 'target'
 
     .delegate 'button.create', 'click', (e) ->
       getTemplate $(e.target).data('slug'), (template) ->

--- a/lib/target.coffee
+++ b/lib/target.coffee
@@ -37,11 +37,12 @@ stopTargeting = (e) ->
 
 
 enterItem = (e) ->
-  item = $(this).attr('data-id')
+  item = ($item = $(this)).attr('data-id')
   if targeting
     $("[data-id=#{item}]").addClass('target')
-    key = $(this).parents('.page:first').data('key')
-    $('.page').trigger('align-item', {key, id:item})
+    key = ($page = $(this).parents('.page:first')).data('key')
+    place = $item.offset().top + $page.scrollTop()
+    $('.page').trigger('align-item', {key, id:item, place})
 
 leaveItem = (e) ->
   if targeting
@@ -69,8 +70,9 @@ alignItem = (e, align) ->
   return if $page.data('key') == align.key
   $item = $page.find(".item[data-id=#{align.id}]")
   return unless $item.length
-  position = $item.offset().top + $page.scrollTop() - $page.height()/2
-  $page.stop().animate {scrollTop: position}, 'slow'
+  place = align.place || $page.height()/2
+  offset = $item.offset().top + $page.scrollTop() - place
+  $page.stop().animate {scrollTop: offset}, 'slow'
 
 
 

--- a/lib/target.coffee
+++ b/lib/target.coffee
@@ -1,0 +1,68 @@
+# Manage the .target highlighting
+
+targeting = false
+item = null
+action = null
+
+
+
+bind = ->
+  $(document)
+    .keydown (e) -> startTargeting e if e.keyCode = 16        
+    .keyup (e) -> stopTargeting e if e.keyCode = 16
+  $('.main')
+    .delegate '.item', 'mouseenter', enterItem
+    .delegate '.item', 'mouseleave', leaveItem
+    .delegate '.action', 'mouseenter', enterAction
+    .delegate '.action', 'mouseleave', leaveAction
+    .delegate '.page', 'align-item', alignItem
+
+
+
+
+startTargeting = (e) ->
+  targeting = true
+
+stopTargeting = (e) ->
+  targeting = false
+  $('.item, .action').removeClass 'target'
+
+
+
+enterItem = (e) ->
+  item = $(this).attr('data-id')
+  if targeting
+    $(".action[data-id=#{item}]").addClass('target')
+
+leaveItem = (e) ->
+  if targeting
+    $(".action[data-id=#{item}]").removeClass('target')
+  item = null
+
+
+
+enterAction = (e) ->
+  action = $(this).data('id')
+  if targeting
+    $("[data-id=#{action}]").addClass('target')
+    key = $(this).parents('.page:first').data('key')
+    $('.page').trigger('align-item', {key, id:action})
+
+leaveAction = (e) ->
+  if targeting
+    $("[data-id=#{action}]").removeClass('target')
+  action = null
+
+
+
+alignItem = (e, align) ->
+  $page = $(this)
+  return if $page.data('key') == align.key
+  $item = $page.find(".item[data-id=#{align.id}]")
+  return unless $item.length
+  position = $item.offset().top + $page.scrollTop() - $page.height()/2
+  $page.stop().animate {scrollTop: position}, 'slow'
+
+
+
+module.exports = {bind}

--- a/lib/target.coffee
+++ b/lib/target.coffee
@@ -41,7 +41,7 @@ enterItem = (e) ->
   if targeting
     $("[data-id=#{item}]").addClass('target')
     key = ($page = $(this).parents('.page:first')).data('key')
-    place = $item.offset().top + $page.scrollTop()
+    place = $item.offset().top
     $('.page').trigger('align-item', {key, id:item, place})
 
 leaveItem = (e) ->

--- a/lib/target.coffee
+++ b/lib/target.coffee
@@ -1,4 +1,8 @@
-# Manage the .target highlighting
+# Target handles hovers over items and actions. Other visible
+# items and actions with the same id will highlight. In some cases
+# an event is generated inviting other pages to scroll the item
+# into view. Target tracks hovering even when not requested so
+# that highlighting can be immediate when requested.
 
 targeting = false
 item = null
@@ -8,15 +12,14 @@ action = null
 
 bind = ->
   $(document)
-    .keydown (e) -> startTargeting e if e.keyCode = 16
-    .keyup (e) -> stopTargeting e if e.keyCode = 16
+    .keydown (e) -> startTargeting e if e.keyCode == 16
+    .keyup (e) -> stopTargeting e if e.keyCode == 16
   $('.main')
     .delegate '.item', 'mouseenter', enterItem
     .delegate '.item', 'mouseleave', leaveItem
     .delegate '.action', 'mouseenter', enterAction
     .delegate '.action', 'mouseleave', leaveAction
     .delegate '.page', 'align-item', alignItem
-
 
 
 
@@ -31,7 +34,6 @@ stopTargeting = (e) ->
   targeting = e.shiftKey
   unless targeting
     $('.item, .action').removeClass 'target'
-
 
 
 enterItem = (e) ->

--- a/lib/target.coffee
+++ b/lib/target.coffee
@@ -22,8 +22,9 @@ bind = ->
 
 startTargeting = (e) ->
   targeting = e.shiftKey
-  if targeting and action
-    $("[data-id=#{action}]").addClass('target')
+  if targeting
+    if id = item || action
+      $("[data-id=#{id}]").addClass('target')
 
 
 stopTargeting = (e) ->
@@ -36,11 +37,13 @@ stopTargeting = (e) ->
 enterItem = (e) ->
   item = $(this).attr('data-id')
   if targeting
-    $(".action[data-id=#{item}]").addClass('target')
+    $("[data-id=#{item}]").addClass('target')
+    key = $(this).parents('.page:first').data('key')
+    $('.page').trigger('align-item', {key, id:item})
 
 leaveItem = (e) ->
   if targeting
-    $(".action[data-id=#{item}]").removeClass('target')
+    $('.item, .action').removeClass('target')
   item = null
 
 

--- a/lib/target.coffee
+++ b/lib/target.coffee
@@ -8,7 +8,7 @@ action = null
 
 bind = ->
   $(document)
-    .keydown (e) -> startTargeting e if e.keyCode = 16        
+    .keydown (e) -> startTargeting e if e.keyCode = 16
     .keyup (e) -> stopTargeting e if e.keyCode = 16
   $('.main')
     .delegate '.item', 'mouseenter', enterItem
@@ -21,11 +21,15 @@ bind = ->
 
 
 startTargeting = (e) ->
-  targeting = true
+  targeting = e.shiftKey
+  if targeting and action
+    $("[data-id=#{action}]").addClass('target')
+
 
 stopTargeting = (e) ->
-  targeting = false
-  $('.item, .action').removeClass 'target'
+  targeting = e.shiftKey
+  unless targeting
+    $('.item, .action').removeClass 'target'
 
 
 


### PR DESCRIPTION
This pull request improves the item/action hover logic several ways.

* The hover highlight and scroll effects require that the shift key be pressed.
* Shift will highlight immediately when already hovering.
* Highlight state (class .target) is set and cleared rather than toggled avoiding sync problems.
* Hover over events highlights and scrolls other pages.

The scroll positioning would be better if it aligned like items on item hover. This has many boundary conditions that I will explore and then submit in a later pull request.