### PR TITLE
Update style.css

### DIFF
--- a/client/style.css
+++ b/client/style.css
@@ -243,7 +243,9 @@ p.readout {
 
 .footer {
   clear: both;
-  margin-bottom: 1em; }
+  margin-bottom: 1em;
+  padding-bottom: 500px;
+}
 
 .page {
   float: left;    /* inline-block preferred? */


### PR DESCRIPTION
Add room to bottom of wiki page to make end of scrolling obvious. This is especially useful when shift-hovering for alignment. See example (from internal log inspector).

![screen shot 2015-02-20 at 2 59 23 pm](https://cloud.githubusercontent.com/assets/12127/6310978/4671c518-b911-11e4-8168-f9c8236b4298.png)
