### PR TITLE
tolerate nulls for items and actions

### DIFF
--- a/lib/page.coffee
+++ b/lib/page.coffee
@@ -39,7 +39,7 @@ newPage = (json, site) ->
     context = ['view']
     context.push site if isRemote()
     addContext = (site) -> context.push site if site? and not _.include context, site
-    addContext action.site for action in page.journal.slice(0).reverse()
+    addContext action?.site for action in page.journal.slice(0).reverse()
     context
 
   isPlugin = ->
@@ -70,9 +70,9 @@ newPage = (json, site) ->
     else
       neighbors.push host if host?
     for item in page.story
-      neighbors.push item.site if item.site?
+      neighbors.push item.site if item?.site?
     for action in page.journal
-      neighbors.push action.site if action.site?
+      neighbors.push action.site if action?.site?
     _.uniq neighbors
 
   getTitle = ->
@@ -100,7 +100,7 @@ newPage = (json, site) ->
   seqItems = (each) ->
     emitItem = (i) ->
       return if i >= page.story.length
-      each page.story[i], -> emitItem i+1
+      each page.story[i]||{text:'null'}, -> emitItem i+1
     emitItem 0
 
   addParagraph = (text) ->
@@ -114,7 +114,7 @@ newPage = (json, site) ->
     sections = nowSections (new Date).getTime()
     emitAction = (i) ->
       return if i >= page.journal.length
-      action = page.journal[i]
+      action = page.journal[i]||{}
       bigger = action.date || 0
       separator = null
       for section in sections

--- a/lib/refresh.coffee
+++ b/lib/refresh.coffee
@@ -238,13 +238,9 @@ renderPageIntoPageElement = (pageObject, $page) ->
   emitTimestamp $header, $page, pageObject
 
   pageObject.seqItems (item, done) ->
-    if item?.type and item?.id
-      $item = $ """<div class="item #{item.type}" data-id="#{item.id}">"""
-      $story.append $item
-      plugin.do $item, item, done
-    else
-      $story.append $ """<div><p class="error">Can't make sense of story[#{i}]</p></div>"""
-      done()
+    $item = $ """<div class="item #{item.type}" data-id="#{item.id}">"""
+    $story.append $item
+    plugin.do $item, item, done
 
   pageObject.seqActions (each, done) ->
     addToJournal $journal, each.separator if each.separator

--- a/lib/revision.coffee
+++ b/lib/revision.coffee
@@ -5,7 +5,7 @@
 apply = (page, action) ->
 
   order = ->
-    (item.id for item in page.story||[])
+    (item?.id for item in page.story||[])
 
   add = (after, item) ->
     index = order().indexOf(after) + 1
@@ -47,7 +47,7 @@ create = (revIndex, data) ->
   revJournal = data.journal[0..revIndex]
   revPage = {title: data.title, story: []}
   for action in revJournal
-    apply revPage, action
+    apply revPage, action||{}
   return revPage
 
 module.exports = {create, apply}


### PR DESCRIPTION
We've seen trouble rendering items cascade backwards through successfully rendered items. We're traced this to unexpected null items in a story. This pull request makes rendering of both items and actions more tolerant of nulls by carrying on as best as can be expected.

![image](https://cloud.githubusercontent.com/assets/12127/6433621/853a4f0e-c028-11e4-99e2-4ee937b57220.png)

