### PR TITLE
correct page flag's href after fork

### DIFF
--- a/lib/pageHandler.coffee
+++ b/lib/pageHandler.coffee
@@ -181,7 +181,7 @@ pageHandler.put = ($page, action) ->
     # pull remote site closer to us
     $page.find('h1').prop('title',location.host)
     $page.find('h1 img').attr('src', '/favicon.png')
-    $page.find('h1 a').attr('href', '/')
+    $page.find('h1 a').attr('href', "/view/welcome-visitors/view/#{pagePutInfo.slug}").attr('target',location.host)
     $page.data('site', null)
     $page.removeClass('remote')
     #STATE -- update url when site changes


### PR DESCRIPTION
The pageHandler rewrites the dom of a page when forked so that it appears to have come from the origin. This commit revises this logic to make an acceptable href for the page's flag.

This commit addresses the issue raised in https://github.com/fedwiki/wiki-node/issues/44 where a recently forked page could not be dropped on a Factory with expected result.