### PR TITLE
html formatted error message now requires html plugin

### DIFF
--- a/client/style.css
+++ b/client/style.css
@@ -3,6 +3,11 @@
   padding: 0.8em;
 }
 
+pre.error {
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+}
+
 a {
   text-decoration: none; }
 

--- a/lib/pageHandler.coffee
+++ b/lib/pageHandler.coffee
@@ -64,7 +64,9 @@ recursiveGet = ({pageInformation, whenGotten, whenNotGotten, localContext}) ->
         console.log 'pageHandler.get error', xhr, xhr.status, type, msg
         #NEWPAGE trouble from PageHandler.get
         troublePageObject = newPage {title: "Trouble: Can't Get Page"}, null
-        troublePageObject.addParagraph """
+        troublePageObject.addItem
+          type: 'html'
+          text: """
 The page handler has run into problems with this   request.
 <pre class=error>#{JSON.stringify pageInformation}</pre>
 The requested url.


### PR DESCRIPTION
This corrects a formatting problem exposed by https://github.com/fedwiki/wiki-node/issues/45.
Formatting could be improved but this at least corrects the regression.