### PR TITLE
Add site name mouse over to forks in journal

### DIFF
--- a/lib/addToJournal.coffee
+++ b/lib/addToJournal.coffee
@@ -7,7 +7,9 @@ actionSymbols = require './actionSymbols'
 
 module.exports = ($journal, action) ->
   $page = $journal.parents('.page:first')
-  title = action.type || 'separator'
+  title = ''
+  title += "#{action.site}\n" if action.site?
+  title += action.type || 'separator'
   title += " #{util.formatElapsedTime(action.date)}" if action.date?
   $action = $("""<a href="#" /> """).addClass("action").addClass(action.type || 'separator')
     .text(action.symbol || actionSymbols.symbols[action.type])


### PR DESCRIPTION
Paired with @WardCunningham to add the site location to the hover effect in the journal, for actions that have an associated site.