### PR TITLE
Resize and compress large images on drop.

### DIFF
--- a/lib/factory.coffee
+++ b/lib/factory.coffee
@@ -95,7 +95,7 @@ bind = ($item, item) ->
       if majorType == "image"
         reader.onload = (loadEvent) ->
           item.type = 'image'
-          item.url = loadEvent.target.result
+          item.url = resizeImage loadEvent.target.result
           item.caption ||= "Uploaded image"
           syncEditAction()
         reader.readAsDataURL(file)
@@ -158,5 +158,24 @@ arrayToJson = (array) ->
       obj[k] = v if v? && (v.match /\S/) && v != 'NULL'
     obj
   (rowToObject row for row in array)
+
+# from http://www.benknowscode.com/2014/01/resizing-images-in-browser-using-canvas.html
+# Patrick Oswald version from comment, coffeescript and further simplification for wiki
+
+resizeImage = (dataURL) ->
+  smallEnough = (src) ->
+    src.width <= 500 || src.height <= 300
+  squeezeSteps = (src) ->
+    return src if smallEnough src
+    canvas = document.createElement 'canvas'
+    canvas.width = cW = src.width / 2
+    canvas.height = cH = src.height / 2
+    context = canvas.getContext '2d'
+    context.drawImage src, 0, 0, cW, cH
+    return squeezeSteps canvas
+  img = new Image
+  img.src = dataURL
+  return dataURL if smallEnough img
+  squeezeSteps(img).toDataURL 'image/jpeg', .5  # medium quality encoding
 
 module.exports = {emit, bind}


### PR DESCRIPTION
This pull request is for the feature discussed in issue #117.

We stop short of reading or revising EXIF metadata. This leads to some drops appearing sideways.