### PR TITLE
shift-double-click for html or markdown

### DIFF
--- a/lib/paragraph.coffee
+++ b/lib/paragraph.coffee
@@ -6,6 +6,12 @@ editor = require './editor'
 resolve = require './resolve'
 itemz = require './itemz'
 
+type = (text) ->
+  if text.match /<(i|b|p|a|h\d|hr|br|li|img|div|span|table|blockquote)\b.*?>/i
+    'html'
+  else
+    'markdown'
+
 emit = ($item, item) ->
   for text in item.text.split /\n\n+/
     $item.append "<p>#{resolve.resolveLinks(text)}</p>" if text.match /\S/
@@ -13,7 +19,7 @@ emit = ($item, item) ->
 bind = ($item, item) ->
   $item.dblclick (e) ->
     if e.shiftKey
-      item.type = 'html'
+      item.type = type(item.text)
       itemz.replaceItem $item, 'paragraph', item
     else
       editor.textEditor $item, item, {'append': true}


### PR DESCRIPTION
Wiki shortens slightly the path to making Paragraphs over other item types. This pull requests extends slightly the shift-double-click hack that converts Paragraphs to the now sanitized HTML type by considering alternatives.

Shift-double-click now inspects the Paragraph for the presence of various tags before converting to HTML. If absent, the converted item will be type Markdown instead. This is the list of expected tags extracted from the regular expression used to perform the test.

```
(i|b|p|a|h\d|hr|br|li|img|div|span|table|blockquote)
```