### PR TITLE
Drag and drop to import from export files

### DIFF
--- a/lib/importer.coffee
+++ b/lib/importer.coffee
@@ -17,8 +17,11 @@ emit = ($item, item) ->
     result = []
     for slug, page of pages
       line = "<a href=#{slug}>#{ page.title || slug }</a>"
-      if page.journal && (date = page.journal[page.journal.length - 1].date)
-        line += " &nbsp; from #{util.formatElapsedTime date}"
+      if page.journal
+        if (date = page.journal[page.journal.length - 1].date)
+          line += " &nbsp; from #{util.formatElapsedTime date}"
+        else
+          line += " &nbsp; from revision #{page.journal.length - 1}"
       result.push line
     result.join '<br>'
 

--- a/lib/importer.coffee
+++ b/lib/importer.coffee
@@ -34,8 +34,9 @@ emit = ($item, item) ->
 bind = ($item, item) ->
   $item.find('a').click (e) ->
     slug = $(e.target).attr('href')
-    page = $(e.target).parents('.page') unless e.shiftKey
-    link.showResult newPage(item.pages[slug]), page
+    $page = $(e.target).parents('.page') unless e.shiftKey
+    pageObject = newPage(item.pages[slug])
+    link.showResult pageObject, {$page, rev:pageObject.getRevision()}
 
     false
 

--- a/lib/importer.coffee
+++ b/lib/importer.coffee
@@ -1,0 +1,41 @@
+# An Importer plugin completes the ghost page created upon drop of a site export file.
+
+util = require './util'
+link = require './link'
+newPage = require('./page').newPage
+
+expand = (text)->
+  text
+    .replace /&/g, '&amp;'
+    .replace /</g, '&lt;'
+    .replace />/g, '&gt;'
+
+
+emit = ($item, item) ->
+
+  render = (pages) ->
+    result = []
+    for slug, page of pages
+      line = "<a href=#{slug}>#{ page.title || slug }</a>"
+      if page.journal && (date = page.journal[page.journal.length - 1].date)
+        line += " &nbsp; from #{util.formatElapsedTime date}"
+      result.push line
+    result.join '<br>'
+
+  $item.append """
+    <p style="background-color:#eee;padding:15px;">
+      #{render item.pages}
+    </p>
+  """
+
+bind = ($item, item) ->
+  $item.find('a').click (e) ->
+    slug = $(e.target).attr('href')
+    page = $(e.target).parents('.page') unless e.shiftKey
+    link.showResult newPage(item.pages[slug]), page
+
+    false
+
+  # $item.dblclick -> wiki.textEditor $item, item
+
+module.exports = {emit, bind}

--- a/lib/importer.coffee
+++ b/lib/importer.coffee
@@ -4,19 +4,18 @@ util = require './util'
 link = require './link'
 newPage = require('./page').newPage
 
-expand = (text)->
+escape = (text)->
   text
     .replace /&/g, '&amp;'
     .replace /</g, '&lt;'
     .replace />/g, '&gt;'
-
 
 emit = ($item, item) ->
 
   render = (pages) ->
     result = []
     for slug, page of pages
-      line = "<a href=#{slug}>#{ page.title || slug }</a>"
+      line = "<a href=#{slug}>#{ escape(page.title) || slug }</a>"
       if page.journal
         if (date = page.journal[page.journal.length - 1].date)
           line += " &nbsp; from #{util.formatElapsedTime date}"
@@ -37,9 +36,6 @@ bind = ($item, item) ->
     $page = $(e.target).parents('.page') unless e.shiftKey
     pageObject = newPage(item.pages[slug])
     link.showResult pageObject, {$page, rev:pageObject.getRevision()}
-
     false
-
-  # $item.dblclick -> wiki.textEditor $item, item
 
 module.exports = {emit, bind}

--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -14,6 +14,8 @@ link = require './link'
 target = require './target'
 
 asSlug = require('./page').asSlug
+newPage = require('./page').newPage
+
 
 $ ->
   dialog.emit()
@@ -48,6 +50,26 @@ $ ->
       #     Error on #{settings.url}: #{request.responseText}
       #   </li>
       # """
+
+  readFile = (file) ->
+    if file?.type == 'application/json'
+      reader = new FileReader()
+      reader.onload = (e) ->
+        result = e.target.result
+        pages = JSON.parse result
+        resultPage = newPage()
+        resultPage.setTitle "Import from #{file.name}"
+        resultPage.addParagraph """
+          Import of #{Object.keys(pages).length} pages
+          (#{file.size} bytes)
+          from an export file dated #{file.lastModifiedDate}.
+        """
+        resultPage.addItem
+          type: 'markdown'
+          pages: pages
+          text: (page.title || slug for slug, page of pages).join "\n"
+        link.showResult resultPage
+      reader.readAsText(file)
 
   getTemplate = (slug, done) ->
     return done(null) unless slug
@@ -144,6 +166,7 @@ $ ->
     .bind 'dragover', (evt) -> evt.preventDefault()
     .bind "drop", drop.dispatch
       page: (item) -> link.doInternalLink item.slug, null, item.site
+      file: (file) -> readFile file
 
   $(".provider input").click ->
     $("footer input:first").val $(this).attr('data-provider')

--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -67,10 +67,7 @@ $ ->
           (#{commas file.size} bytes)
           from an export file dated #{file.lastModifiedDate}.
         """
-        resultPage.addItem
-          type: 'markdown'
-          pages: pages
-          text: (page.title || slug for slug, page of pages).join "\n"
+        resultPage.addItem {type: 'importer', pages: pages}
         link.showResult resultPage
       reader.readAsText(file)
 

--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -51,6 +51,9 @@ $ ->
       #   </li>
       # """
 
+  commas = (number) ->
+    "#{number}".replace /(\d)(?=(\d\d\d)+(?!\d))/g, "$1,"
+
   readFile = (file) ->
     if file?.type == 'application/json'
       reader = new FileReader()
@@ -61,7 +64,7 @@ $ ->
         resultPage.setTitle "Import from #{file.name}"
         resultPage.addParagraph """
           Import of #{Object.keys(pages).length} pages
-          (#{file.size} bytes)
+          (#{commas file.size} bytes)
           from an export file dated #{file.lastModifiedDate}.
         """
         resultPage.addItem

--- a/lib/link.coffee
+++ b/lib/link.coffee
@@ -31,12 +31,14 @@ doInternalLink = (name, $page, site=null) ->
   showPage(name,site)
   active.set($('.page').last())
 
-showResult = (resultObject, $page) ->
-  $($page).nextAll().remove() if $page?
-  lineup.removeAllAfterKey $($page).data('key') if $page?
-  $resultPage = createPage(resultObject.getSlug()).addClass('ghost')
-  $resultPage.appendTo($('.main'))
-  refresh.buildPage( resultObject, $resultPage )
+showResult = (resultObject, options={}) ->
+  $(options.$page).nextAll().remove() if options.$page?
+  lineup.removeAllAfterKey $(options.$page).data('key') if options.$page?
+  slug = resultObject.getSlug()
+  slug += "_rev#{options.rev}" if options.rev?
+  $page = createPage(slug).addClass('ghost')
+  $page.appendTo($('.main'))
+  refresh.buildPage( resultObject, $page )
   active.set($('.page').last())
 
 pageEmitter.on 'show', (page) ->

--- a/lib/link.coffee
+++ b/lib/link.coffee
@@ -31,14 +31,14 @@ doInternalLink = (name, $page, site=null) ->
   showPage(name,site)
   active.set($('.page').last())
 
-showResult = (resultObject, options={}) ->
+showResult = (pageObject, options={}) ->
   $(options.$page).nextAll().remove() if options.$page?
   lineup.removeAllAfterKey $(options.$page).data('key') if options.$page?
-  slug = resultObject.getSlug()
+  slug = pageObject.getSlug()
   slug += "_rev#{options.rev}" if options.rev?
   $page = createPage(slug).addClass('ghost')
   $page.appendTo($('.main'))
-  refresh.buildPage( resultObject, $page )
+  refresh.buildPage( pageObject, $page )
   active.set($('.page').last())
 
 pageEmitter.on 'show', (page) ->

--- a/lib/link.coffee
+++ b/lib/link.coffee
@@ -31,10 +31,12 @@ doInternalLink = (name, $page, site=null) ->
   showPage(name,site)
   active.set($('.page').last())
 
-showResult = (pageObject) ->
-  $page = createPage(pageObject.getSlug()).addClass('ghost')
-  $page.appendTo($('.main'))
-  refresh.buildPage( pageObject, $page )
+showResult = (resultObject, $page) ->
+  $($page).nextAll().remove() if $page?
+  lineup.removeAllAfterKey $($page).data('key') if $page?
+  $resultPage = createPage(resultObject.getSlug()).addClass('ghost')
+  $resultPage.appendTo($('.main'))
+  refresh.buildPage( resultObject, $resultPage )
   active.set($('.page').last())
 
 pageEmitter.on 'show', (page) ->

--- a/lib/page.coffee
+++ b/lib/page.coffee
@@ -85,8 +85,14 @@ newPage = (json, site) ->
     page.journal.length-1
 
   getTimestamp = ->
-    date = page.journal[getRevision()].date
-    if date? then formatDate(date) else "Revision #{getRevision()}"
+    action = page.journal[getRevision()]
+    if action?
+      if action.date?
+        formatDate(action.date)
+      else
+        "Revision #{getRevision()}"
+    else
+      "Unrecorded Date"
 
   addItem = (item) ->
     item = _.extend {}, {id: random.itemId()}, item

--- a/lib/plugins.coffee
+++ b/lib/plugins.coffee
@@ -8,3 +8,4 @@ window.plugins =
   paragraph: require './paragraph'
   image: require './image'
   future: require './future'
+  importer: require './importer'


### PR DESCRIPTION
The server will bundle all site pages into an export file easily downloaded into a single file. [json](http://divergence.hapgood.net/system/export.json)

This pull request implements a simple way to recover individual pages from such a backup.

* Users export their sites to their own computer for backup.
* To recover a page, simply drag the backup file into the wiki tab.
* A ghost page opens listing the contents of the backup.
* Click any title to see the backup version as another ghost page.
* If it is the wanted page, fork it over your mistake.

This is what it might look like while recovering an accidentally damaged welcome page. Notice that both pages are ghostly because they do not yet exist in the site. The welcome page will turn white if forked.

![image](https://cloud.githubusercontent.com/assets/12127/8153804/f1c0aba2-12e7-11e5-847f-79b7ea6ee9ff.png)

We use the existing fork mechanism on the server to import files. This places an upper limit on the size of a page (5Mb) but not an upper limit on the size of a site. A future commit will add a convenient way to load all pages of an export into a new empty site.