### PR TITLE
record more useful info when file drop fails

### DIFF
--- a/lib/factory.coffee
+++ b/lib/factory.coffee
@@ -114,7 +114,11 @@ bind = ($item, item) ->
         reader.readAsText(file)
       else
         punt
-          file: file
+          name: file.name
+          type: file.type
+          size: file.size
+          fileName: file.fileName
+          lastModified: file.lastModified
 
   $item.dblclick (e) ->
     if e.shiftKey


### PR DESCRIPTION
This information is logged in the action and available by double-clicking the timestamp.

![image](https://cloud.githubusercontent.com/assets/12127/8223017/ee652338-1527-11e5-93fd-9577ee075c09.png)
