### PR TITLE
show how to add things to ipfs

### DIFF
--- a/lib/factory.coffee
+++ b/lib/factory.coffee
@@ -10,6 +10,12 @@ editor = require './editor'
 synopsis = require './synopsis'
 drop = require './drop'
 
+# ipfs things
+fileStream = require 'filereader-stream'
+ipfsApi = require 'ipfs-api'
+# TODO: change api addr + ports from user config
+ipfs = ipfsApi '127.0.0.1', '5001'
+
 escape = (line) ->
   line
     .replace(/&/g, '&amp;')
@@ -93,12 +99,21 @@ bind = ($item, item) ->
       [majorType, minorType] = file.type.split("/")
       reader = new FileReader()
       if majorType == "image"
-        reader.onload = (loadEvent) ->
-          item.type = 'image'
-          item.url = resizeImage loadEvent.target.result
-          item.caption ||= "Uploaded image"
-          syncEditAction()
-        reader.readAsDataURL(file)
+        # let's read the file as a stream.
+        addFileToIpfs file, (err, hashes) ->
+          throw err if err
+          # now do the original wiki-client stuff.
+          # we read the file twice here-- once via the stream, and once
+          # more here. perhaps this part can be done at the same time.
+          reader.onload = (loadEvent) ->
+            item.type = 'image'
+            item.url = resizeImage loadEvent.target.result
+            item.caption ||= "Uploaded image"
+            # you can add the ipfsHash to
+            # item.ipfsHash = hashes.Hash
+            syncEditAction()
+          reader.readAsDataURL(file)
+
       else if majorType == "text"
         reader.onload = (loadEvent) ->
           result = loadEvent.target.result
@@ -181,5 +196,17 @@ resizeImage = (dataURL) ->
   img.src = dataURL
   return dataURL if smallEnough img
   squeezeSteps(img).toDataURL 'image/jpeg', .5  # medium quality encoding
+
+addFileToIpfs = (file, cb) ->
+  console.log 'adding ' + file.name + ' to ipfs'
+  addfile = { path: file.name, contents: fileStream(file) }
+  addopts = { wrap: true } # wrap with a dir to preserve filename.
+  ipfs.add addfile, addopts, (err, res) ->
+    return cb(err) if err
+    unless Array.isArray res
+      res = [res]
+    for r in res
+      console.log('added', r.Hash, r.Name)
+    cb(null, res)
 
 module.exports = {emit, bind}

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     }
   ],
   "dependencies": {
+    "filereader-stream": "^0.2.0",
+    "ipfs-api": "^2.1.6",
     "underscore": "*"
   },
   "scripts": {


### PR DESCRIPTION
### Note: this PR is not to merge, but to show how it works.
---

This commit is a very simple example of how to use ipfs to store
assets. We basically just read a stream of data and pass it to
ipfs.add(stream). The response includes the hashes of files added.

(Of course, actually hosting the server-side fed wiki code on ipfs
and doing everything client side is possible. This is just a small
bit to start :)

On backing up the content:

This commit shows how to add content to an ipfs node. the node
will also "pin" the content, which means the node will back it up
and serve it to other nodes. Pins can be removed with:

    ipfs pin rm -r <hash>

On the API Address:

The ipfsApi('localhost', 5001) can be changed to point to whatever
node can be written to. Note that for now, while ipfs is still
figuring out either (a) the way to do a writable HTTP gateway with
low permissions, and (b) the node-ipfs implementation, we need to
setup CORS to work correctly with the server. You should be able to
do:

    ipfs config --json API.HTTPHeaders.Access-Control-Allow-Origin '["localhost:3000", "localhost:5001"]'

(or whatever ports you're using for fedwiki and the ipfs api)
If it doesn't appear to work, you can just run:

    ipfs daemon --unrestricted-api

But please do not run ipfs nodes like this all the time. it exposes
the API to any user.