### PR TITLE
speed up sitemap loading by 4x

### DIFF
--- a/lib/neighborhood.coffee
+++ b/lib/neighborhood.coffee
@@ -8,7 +8,7 @@ module.exports = neighborhood = {}
 
 neighborhood.sites = {}
 nextAvailableFetch = 0
-nextFetchInterval = 2000
+nextFetchInterval = 500
 
 populateSiteInfoFor = (site,neighborInfo)->
   return if neighborInfo.sitemapRequestInflight


### PR DESCRIPTION
This changes the delay between loading sitemaps to 1/2 second. Let's make this 4x improvement the norm. This builds on @paul90's months of improvements to sitemap caching and now activity configuration and rendering. 