### PR TITLE
add footer link to search choice ghost page

### DIFF
--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -184,7 +184,7 @@ $ ->
       resultPage.addParagraph "Find pages sharing any of these items."
       resultPage.addItem
         type: 'search'
-        text: "SEARCH OR ITEMS #{(item.id for item in pageObject.getRawPage().story).join ' '}"
+        text: "SEARCH ANY ITEMS #{(item.id for item in pageObject.getRawPage().story).join ' '}"
       $page.nextAll().remove() unless e.shiftKey
       lineup.removeAllAfterKey(key) unless e.shiftKey
       link.showResult resultPage

--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -162,6 +162,33 @@ $ ->
     .delegate '.score', 'hover', (e) ->
       $('.main').trigger 'thumb', $(e.target).data('thumb')
 
+    .delegate 'a.search', 'click', (e) ->
+      $page = $(e.target).parents('.page')
+      key = $page.data('key')
+      pageObject = lineup.atKey key
+      resultPage = newPage()
+      resultPage.setTitle "Search from '#{pageObject.getTitle()}'"
+      resultPage.addParagraph """
+          Search for pages related to '#{pageObject.getTitle()}'.
+          Each search on this page will find pages related in a different way.
+          Choose the search of interest. Be patient.
+      """
+      resultPage.addParagraph "Find pages with links to this title."
+      resultPage.addItem
+        type: 'search'
+        text: "SEARCH LINKS #{pageObject.getSlug()}"
+      resultPage.addParagraph "Find pages neighboring  this site."
+      resultPage.addItem
+        type: 'search'
+        text: "SEARCH SITES #{pageObject.getRemoteSite(location.host)}"
+      resultPage.addParagraph "Find pages sharing any of these items."
+      resultPage.addItem
+        type: 'search'
+        text: "SEARCH OR ITEMS #{(item.id for item in pageObject.getRawPage().story).join ' '}"
+      $page.nextAll().remove() unless e.shiftKey
+      lineup.removeAllAfterKey(key) unless e.shiftKey
+      link.showResult resultPage
+
     .bind 'dragenter', (evt) -> evt.preventDefault()
     .bind 'dragover', (evt) -> evt.preventDefault()
     .bind "drop", drop.dispatch

--- a/lib/refresh.coffee
+++ b/lib/refresh.coffee
@@ -179,7 +179,8 @@ emitFooter = ($footer, pageObject) ->
   $footer.append """
     <a id="license" href="http://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> .
     <a class="show-page-source" href="/#{slug}.json?random=#{random.randomBytes(4)}" title="source">JSON</a> .
-    <a href= "//#{host}/#{slug}.html" target="#{host}">#{host} </a>
+    <a href= "//#{host}/#{slug}.html" target="#{host}">#{host} </a> .
+    <a href= "#" class=search>search</a>
   """
 
 editDate = (journal) ->


### PR DESCRIPTION
This experimental feature is not ready to be merged.

This commit adds a link to a search choice page in the footer of every wiki page.

![image](https://cloud.githubusercontent.com/assets/12127/9513862/9bae49ea-4c49-11e5-882a-8a38e4e455f9.png)

The link opens a ghost page offering three different searches.

![image](https://cloud.githubusercontent.com/assets/12127/9513914/14e60f64-4c4a-11e5-84bd-a01464a1fdde.png)

This represents one component of a larger search project.

http://ward.asia.wiki.org/about-search-plugin.html
http://ward.asia.wiki.org/distributed-search.html