### PR TITLE
Batalyx/slug after pipe

### DIFF
--- a/lib/resolve.coffee
+++ b/lib/resolve.coffee
@@ -40,6 +40,10 @@ resolve.resolveLinks = (string, sanitize=escape) ->
     slug = asSlug name
     stash """<a class="internal" href="/#{slug}.html" data-page-name="#{slug}" title="#{resolve.resolutionContext.join(' => ')}">#{escape name}</a>"""
 
+  internalWithPipe = (match, name, slug) ->
+    slug = asSlug if slug then slug else name # if someone enters something unsluggish as slug
+    stash """<a class="internal" href="/#{slug}.html" data-page-name="#{slug}" title="#{resolve.resolutionContext.join(' => ')}">#{escape name}</a>"""
+
   external = (match, href, protocol, rest) ->
     stash """<a class="external" target="_blank" href="#{href}" title="#{href}" rel="nofollow">#{escape rest} <img src="/images/external-link-ltr-icon.png"></a>"""
 
@@ -49,11 +53,12 @@ resolve.resolveLinks = (string, sanitize=escape) ->
   #   - remaining text is sanitized and/or escaped
   #   - unique markers are replaced with unstashed links
 
+
   string = string
     .replace /〖(\d+)〗/g, "〖 $1 〗"
-    .replace /\[\[([^\]]+)\]\]/gi, internal
+    .replace /\[\[([^\]|]+)\]\]/gi, internal
+    .replace /\[\[([^\]]+)(\|[^\]]+)\]\]/gi, internalWithPipe
     .replace /\[((http|https|ftp):.*?) (.*?)\]/gi, external
   sanitize string
     .replace /〖(\d+)〗/g, unstash
-
 

--- a/test/resolve.coffee
+++ b/test/resolve.coffee
@@ -46,5 +46,10 @@ describe 'resolve', ->
     it 'should be adulterated where unexpected', ->
       expect(r 'foo 〖12〗 bar').to.eql "foo 〖 12 〗 bar"
 
+  describe 'piped slug', ->
+    it 'should take slug after pipe', ->
+      expect(r '[[foo|bar]]').to.contain 'href="/bar.html"'
 
+    it 'should slugify text after pipe', ->
+      expect(r '[[baz|Foo Bar]]').to.contain 'href="/foo-bar.html"'
 


### PR DESCRIPTION
As in Wikipedia, internal link [[foo|bar]] results to slug 'bar' instead
of 'foo'.  This is a great help with languages like Finnish, where the
body of the word can change. Now several links can point to one page.

I've tested this only in a small scale. It seem's to work :-) But I've had all kinds of odd problems, when trying to integrate this. Installing npm from github has not worked, and recompiling either until using 'npm link' in web-client directory, installing grunt, etc. So, I'd be happy if someone with more experience with fedwiki & node development would try this out.