### PR TITLE
Add a paper scrollable div inside the pages viewport

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -50,7 +50,7 @@ module.exports = function (grunt) {
       // build the client that we will include in the package
       packageClient: {
         src: ['./client.coffee'],
-        dest: 'client/client.max.js',
+        dest: 'client/client.js',
         options: {
           transform: ['coffeeify'],
           browserifyOptions: {
@@ -88,7 +88,7 @@ module.exports = function (grunt) {
                   ' Licensed <%= _.pluck(pkg.licenses, "type").join(", ") %> */'
         },
         files: {
-          'client/client.js': ['client/client.max.js']
+          'client/client.js': ['client/client.js']
         }
       }
     },

--- a/client/style.css
+++ b/client/style.css
@@ -145,13 +145,14 @@ footer {
   width: 100%; }
 
 .journal {
-  width: 420px;
+  /*width: 420px;*/
   overflow-x: hidden;
   margin-top: 2px;
   clear: both;
   background-color: #eeeeee;
   overflow: auto;
-  padding: 3px; }
+  /*padding: 3px; */
+}
 
 .action.fork {
   color: black; }
@@ -268,7 +269,7 @@ p.readout {
 .page {
   float: left;    /* inline-block preferred? */
   margin: 8px;
-  padding: 0 31px;
+  /* padding: 0 31px; */
   width: 430px;
   background-color: white;
   height: 100%;
@@ -278,16 +279,20 @@ p.readout {
     box-shadow: 2px 1px 24px rgba(0, 0, 0, 0.4);
     z-index: 10; }
 
-.page.plugin {
+.paper.plugin {
   box-shadow: inset 0px 0px 40px 0px rgba(0,220,0,.5);
 }
 
-.page.local {
+.paper.local {
   box-shadow: inset 0px 0px 40px 0px rgba(220,180,0,.7);
 }
 
-.page.remote {
+.paper.remote {
   box-shadow: inset 0px 0px 40px 0px rgba(0,180,220,.5);
+}
+
+.paper {
+  padding: 30px;
 }
 
 .factory,

--- a/lib/link.coffee
+++ b/lib/link.coffee
@@ -6,15 +6,18 @@
 lineup = require './lineup'
 active = require './active'
 refresh = require './refresh'
-{asSlug, pageEmitter} = require './page'
+{asTitle, asSlug, pageEmitter} = require './page'
 
 createPage = (name, loc) ->
   site = loc if loc and loc isnt 'view'
+  title = asTitle(name)
   $page = $ """
     <div class="page" id="#{name}">
-      <div class="twins"> <p> </p> </div>
-      <div class="header">
-        <h1> <img class="favicon" src="#{ if site then "//#{site}" else "" }/favicon.png" height="32px"> #{name} </h1>
+      <div class="paper">
+        <div class="twins"> <p> </p> </div>
+        <div class="header">
+          <h1> <img class="favicon" src="#{ if site then "//#{site}" else "" }/favicon.png" height="32px"> #{title} </h1>
+        </div>
       </div>
     </div>
   """

--- a/lib/page.coffee
+++ b/lib/page.coffee
@@ -16,6 +16,9 @@ pageEmitter = new EventEmitter
 asSlug = (name) ->
   name.replace(/\s/g, '-').replace(/[^A-Za-z0-9-]/g, '').toLowerCase()
 
+asTitle = (slug) ->
+  slug.replace(/-/g, ' ')
+
 nowSections = (now) ->
   [
     {symbol: '❄', date: now-1000*60*60*24*366, period: 'a Year'}
@@ -166,4 +169,4 @@ newPage = (json, site) ->
 
   {getRawPage, getContext, isPlugin, isRemote, isLocal, getRemoteSite, getRemoteSiteDetails, getSlug, getNeighbors, getTitle, setTitle, getRevision, getTimestamp, addItem, getItem, addParagraph, seqItems, seqActions, become, siteLineup, merge, apply}
 
-module.exports = {newPage, asSlug, pageEmitter}
+module.exports = {newPage, asSlug, asTitle, pageEmitter}

--- a/lib/refresh.coffee
+++ b/lib/refresh.coffee
@@ -231,8 +231,11 @@ renderPageIntoPageElement = (pageObject, $page) ->
   resolve.resolutionContext = pageObject.getContext()
 
   $page.empty()
+  $paper = $("<div class='paper' />")
+  $paper.addClass('remote') if pageObject.isRemote()
+  $page.append($paper)
   [$twins, $header, $story, $journal, $footer] = ['twins', 'header', 'story', 'journal', 'footer'].map (className) ->
-    $("<div />").addClass(className).appendTo($page)
+    $("<div />").addClass(className).appendTo($paper)
 
   emitHeader $header, $page, pageObject
   emitTimestamp $header, $page, pageObject
@@ -260,7 +263,7 @@ createMissingFlag = ($page, pageObject) ->
 
 rebuildPage = (pageObject, $page) ->
   $page.addClass('local') if pageObject.isLocal()
-  $page.addClass('remote') if pageObject.isRemote()
+  # $page.addClass('remote') if pageObject.isRemote()
   $page.addClass('plugin') if pageObject.isPlugin()
 
   renderPageIntoPageElement pageObject, $page


### PR DESCRIPTION
- This adds a new div called "paper" that contains the scrollable viewport instead of the page.
- Adds a "asTitle" utility method to convert a slug back into a title.

@WardCunningham will check this out for a bit with the various plugins to ensure it doesn't break anything.