### PR TITLE
changed styling of reference-div from background-color to box-shadow …

### DIFF
--- a/client/style.css
+++ b/client/style.css
@@ -379,5 +379,12 @@ textarea {
 }
 
 .reference {
-  background-color: #f0f8ff;
+  box-shadow: 0px 0px 10px 0px rgba(0, 180, 220, 0.5) inset;
+  margin-left: 15px;
+  padding: 7px;
+}
+
+.reference p {
+    margin-top: 3px;
+    margin-bottom: 3px;
 }


### PR DESCRIPTION
…(as external pages have) and added style for paragraphs with the reference-div (according change to remove inline style in wiki-plugin-reference) - addressing #66 - needs the according pull-request on wiki-plugin-request to remove the inline-style there which get's replaced by the new ".reference p" from this change