### PR TITLE
edit item.text even when a plugin won't show

### DIFF
--- a/lib/plugin.coffee
+++ b/lib/plugin.coffee
@@ -51,6 +51,9 @@ plugin.do = plugin.doPlugin = (div, item, done=->) ->
         <button>help</button><br>
       </div>
     """
+    if item.text?
+      div.find('.error').dblclick (e) ->
+        wiki.textEditor div, item
     div.find('button').on 'click', ->
       wiki.dialog ex.toString(), """
         <p> This "#{item.type}" plugin won't show.</p>


### PR DESCRIPTION
We catch errors when rendering plugins and offer help. However, the exception prevents further emit/bind logic, so we find ourselves without the ability to correct simple markup errors.

This pull request adds markup editing even when a plugin doesn't show.

This is especially useful to plugin developers who haven't yet developed their own input validation to prevents a new plugin from throwing errors.