### PR TITLE
lose the ghost flag whenever page forked

### DIFF
--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -145,8 +145,8 @@ $ ->
       else if pageObject.isRemote()
         action.site = pageObject.getRemoteSite()
       if $page.data('rev')?
-        $page.removeClass('ghost')
         $page.find('.revision').remove()
+      $page.removeClass 'ghost'
       pageHandler.put $page, action
 
     .delegate 'button.create', 'click', (e) ->

--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -137,6 +137,7 @@ $ ->
 
     .delegate '.fork-page', 'click', (e) ->
       $page = $(e.target).parents('.page')
+      return if $page.find('.future')
       pageObject = lineup.atKey $page.data('key')
       action = {type: 'fork'}
       if $page.hasClass('local')


### PR DESCRIPTION
We correct a confusing bug where transported pages appear as ghosts but do not lose the ghostly appearance when forked into the origin site. 

We move the ghost-class removal code used when forking from history so that it is applied in all forking cases. No fork ever produces a ghost page.

@opn brought this bug to my attention.