### PR TITLE
set a minimum height on .paper

### DIFF
--- a/client/style.css
+++ b/client/style.css
@@ -288,8 +288,9 @@ p.readout {
 }
 
 .paper {
-  width: 420px;
+  width: 430px;
   padding: 30px;
+  min-height: 100%;
 }
 
 .factory,


### PR DESCRIPTION
prevents bottom box-shadow from appearing partway up page on short pages.

:blush: didn't spot the problem with short pages until after #145 was merged. 