### PR TITLE
prevent origin from being escaped

### DIFF
--- a/views/static.html
+++ b/views/static.html
@@ -25,7 +25,7 @@
   <body>
     <section class='main'>
       {{#pages}}
-      <div class='page' id={{page}} {{{origin}}} {{generated}}>{{{story}}}</div>
+      <div class='page' id={{page}} {{{origin}}} {{{generated}}}>{{{story}}}</div>
       {{/pages}}
     </section>
     <footer>

--- a/views/static.html
+++ b/views/static.html
@@ -25,7 +25,7 @@
   <body>
     <section class='main'>
       {{#pages}}
-      <div class='page' id={{page}} {{origin}} {{generated}}>{{{story}}}</div>
+      <div class='page' id={{page}} {{{origin}}} {{generated}}>{{{story}}}</div>
       {{/pages}}
     </section>
     <footer>


### PR DESCRIPTION
Handlebars 4.x added the escaping of `=`

This fixes fedwiki/wiki-server#117