### PR TITLE
style .paper from classes on parent .page

### DIFF
--- a/client/style.css
+++ b/client/style.css
@@ -275,15 +275,15 @@ p.readout {
     box-shadow: 2px 1px 24px rgba(0, 0, 0, 0.4);
     z-index: 10; }
 
-.paper.plugin {
+.page.plugin > .paper {
   box-shadow: inset 0px 0px 40px 0px rgba(0,220,0,.5);
 }
 
-.paper.local {
+.page.local > .paper {
   box-shadow: inset 0px 0px 40px 0px rgba(220,180,0,.7);
 }
 
-.paper.remote {
+.page.remote > .paper {
   box-shadow: inset 0px 0px 40px 0px rgba(0,180,220,.5);
 }
 

--- a/lib/editor.coffee
+++ b/lib/editor.coffee
@@ -56,7 +56,7 @@ textEditor = ($item, item, option={}) ->
 
       if e.which is $.ui.keyCode.ENTER
         return false unless sel
-        $page = $item.parent().parent()
+        $page = $item.parents('.page')
         text = $textarea.val()
         prefix = text.substring 0, sel.start
         suffix = text.substring(sel.end)

--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -88,7 +88,7 @@ $ ->
   $('.main')
     .delegate '.show-page-source', 'click', (e) ->
       e.preventDefault()
-      $page = $(this).parent().parent()
+      $page = $(this).parents('.page')
       page = lineup.atKey($page.data('key')).getRawPage()
       dialog.open "JSON for #{page.title}",  $('<pre/>').text(JSON.stringify(page, null, 2))
 

--- a/lib/refresh.coffee
+++ b/lib/refresh.coffee
@@ -233,7 +233,6 @@ renderPageIntoPageElement = (pageObject, $page) ->
 
   $page.empty()
   $paper = $("<div class='paper' />")
-  $paper.addClass('remote') if pageObject.isRemote()
   $page.append($paper)
   [$twins, $header, $story, $journal, $footer] = ['twins', 'header', 'story', 'journal', 'footer'].map (className) ->
     $("<div />").addClass(className).appendTo($paper)
@@ -264,7 +263,7 @@ createMissingFlag = ($page, pageObject) ->
 
 rebuildPage = (pageObject, $page) ->
   $page.addClass('local') if pageObject.isLocal()
-  # $page.addClass('remote') if pageObject.isRemote()
+  $page.addClass('remote') if pageObject.isRemote()
   $page.addClass('plugin') if pageObject.isPlugin()
 
   renderPageIntoPageElement pageObject, $page


### PR DESCRIPTION
The .local, .remote and .plugin classes are added to .page divs to add halos and sometimes control behavior. This commit reverses the decision to move this annotation to the recently introduced .page child div.paper which is the medium that scrolls.

Rather than move the annotation, we style the .paper using the css combinator: child selector, denoted by the greater-than arrow. For example, this selector will style the .paper of a .remote page.
```
.page.remote > .paper { ... }
```

Regretfully v0.7.3 was published with css changes that were incompatible with our current .page.local and .page.plugin machinery thus omitting halos in these cases. Here all halos are visible.

![image](https://cloud.githubusercontent.com/assets/12127/13382790/1a59b46c-de32-11e5-9b19-8c2238d788bb.png)
