### PR TITLE
move width from .paper to .page

### DIFF
--- a/client/style.css
+++ b/client/style.css
@@ -266,7 +266,7 @@ p.readout {
   float: left;    /* inline-block preferred? */
   margin: 8px;
   /* padding: 0 31px; */
-  /* width: 430px; */
+  width: 490px; 
   background-color: white;
   height: 100%;
   overflow: auto;
@@ -288,7 +288,7 @@ p.readout {
 }
 
 .paper {
-  width: 430px;
+  /*width: 430px;*/
   padding: 30px;
   min-height: 100%;
 }


### PR DESCRIPTION
This commit corrects two problems observed since we've introduced .paper to carry the colored halo.

* Pages were slightly larger than the div that held them. This meant they could wobble side to side by a few pixels.
* Page width was unconstrained on page load until javascript rewrote the page with the .paper div added.