### PR TITLE
Ward/transport proxy

### DIFF
--- a/lib/future.coffee
+++ b/lib/future.coffee
@@ -5,13 +5,48 @@
 resolve = require './resolve'
 neighborhood = require './neighborhood'
 
+lineup = require './lineup'
+refresh = require './refresh'
+transport = 'http://localhost:4020/proxy'
+
 emit = ($item, item) ->
   $item.append """#{item.text}<br><br><button class="create">create</button> new blank page"""
+  if true
+    $item.append """<br><button class="transport" data-slug=#{item.slug}>create</button> transport from #{transport}"""
+    $item.append "<p class=caption> unavailable</p>"
+    $.get 'http://localhost:4020', ->
+      $item.find('.caption').text 'ready'
   if (info = neighborhood.sites[location.host])? and info.sitemap?
     for item in info.sitemap
       if item.slug.match /-template$/
         $item.append """<br><button class="create" data-slug=#{item.slug}>create</button> from #{resolve.resolveLinks "[[#{item.title}]]"}"""
 
 bind = ($item, item) ->
+  $item.find('button.transport').click (e) ->
+    $item.find('.caption').text 'waiting'
+
+    # duplicatingTransport and Templage logic
+
+    params =
+      title: $item.parents('.page').data('data').title
+
+    req =
+      type: "POST",
+      url: transport
+      dataType: 'json',
+      contentType: "application/json",
+      data: JSON.stringify(params)
+
+    $.ajax(req).done (page) ->
+      $item.find('.caption').text 'ready'
+      console.log 'page', page
+      resultPage = wiki.newPage(page)
+      # wiki.showResult resultPage
+      $page = $item.parents('.page')
+      pageObject = lineup.atKey $page.data('key')
+      pageObject.become(resultPage)
+      page = pageObject.getRawPage()
+      refresh.rebuildPage pageObject, $page.empty()
+
 
 module.exports = {emit, bind}

--- a/lib/future.coffee
+++ b/lib/future.coffee
@@ -28,6 +28,7 @@ bind = ($item, item) ->
 
     params =
       title: $item.parents('.page').data('data').title
+      create: item.create
 
     req =
       type: "POST",
@@ -38,9 +39,7 @@ bind = ($item, item) ->
 
     $.ajax(req).done (page) ->
       $item.find('.caption').text 'ready'
-      console.log 'page', page
       resultPage = wiki.newPage(page)
-      # wiki.showResult resultPage
       $page = $item.parents('.page')
       pageObject = lineup.atKey $page.data('key')
       pageObject.become(resultPage,resultPage)

--- a/lib/future.coffee
+++ b/lib/future.coffee
@@ -7,11 +7,10 @@ neighborhood = require './neighborhood'
 
 lineup = require './lineup'
 refresh = require './refresh'
-transport = 'http://localhost:4020/proxy'
 
 emit = ($item, item) ->
   $item.append """#{item.text}<br><br><button class="create">create</button> new blank page"""
-  if true
+  if transport = item.create?.source?.transport
     $item.append """<br><button class="transport" data-slug=#{item.slug}>create</button> transport from #{transport}"""
     $item.append "<p class=caption> unavailable</p>"
     $.get 'http://localhost:4020', ->
@@ -32,7 +31,7 @@ bind = ($item, item) ->
 
     req =
       type: "POST",
-      url: transport
+      url: item.create.source.transport
       dataType: 'json',
       contentType: "application/json",
       data: JSON.stringify(params)
@@ -44,7 +43,7 @@ bind = ($item, item) ->
       # wiki.showResult resultPage
       $page = $item.parents('.page')
       pageObject = lineup.atKey $page.data('key')
-      pageObject.become(resultPage)
+      pageObject.become(resultPage,resultPage)
       page = pageObject.getRawPage()
       refresh.rebuildPage pageObject, $page.empty()
 

--- a/lib/page.coffee
+++ b/lib/page.coffee
@@ -133,8 +133,9 @@ newPage = (json, site) ->
       each {action, separator}, -> emitAction i+1
     emitAction 0
 
-  become = (template) ->
-    page.story = template?.getRawPage().story || []
+  become = (story, journal) ->
+    page.story = story?.getRawPage().story || []
+    page.journal = journal?.getRawPage().journal if journal?
 
   siteLineup = ->
     slug = getSlug()
@@ -167,6 +168,10 @@ newPage = (json, site) ->
     revision.apply page, action
     site = null if action.site
 
-  {getRawPage, getContext, isPlugin, isRemote, isLocal, getRemoteSite, getRemoteSiteDetails, getSlug, getNeighbors, getTitle, setTitle, getRevision, getTimestamp, addItem, getItem, addParagraph, seqItems, seqActions, become, siteLineup, merge, apply}
+  getCreate = () ->
+    isCreate = (action) -> action.type == 'create'
+    page.journal.reverse().find(isCreate)
+
+  {getRawPage, getContext, isPlugin, isRemote, isLocal, getRemoteSite, getRemoteSiteDetails, getSlug, getNeighbors, getTitle, setTitle, getRevision, getTimestamp, addItem, getItem, addParagraph, seqItems, seqActions, become, siteLineup, merge, apply, getCreate}
 
 module.exports = {newPage, asSlug, asTitle, pageEmitter}

--- a/lib/refresh.coffee
+++ b/lib/refresh.coffee
@@ -293,6 +293,8 @@ cycle = ->
 
   createGhostPage = ->
     title = $("""a[href="/#{slug}.html"]:last""").text() or slug
+    key = $("""a[href="/#{slug}.html"]:last""").parents('.page').data('key')
+    create = lineup.atKey(key).getCreate()
     #NEWPAGE future after failed pageHandler.get then buildPage
     pageObject = newPage()
     pageObject.setTitle(title)
@@ -314,6 +316,7 @@ cycle = ->
         'type': 'future'
         'text': 'We could not find this page in the expected context.'
         'title': title
+        'create': create
       pageObject.addItem
         'type': 'paragraph'
         'text': "We did find the page in your current neighborhood."
@@ -323,6 +326,7 @@ cycle = ->
         'type': 'future'
         'text': 'We could not find this page.'
         'title': title
+        'create': create
 
     buildPage( pageObject, $page ).addClass('ghost')
 


### PR DESCRIPTION
This pull request adds functionality to the Future plugin that will offer to reinvoke a transporter if a link from a previously transported page can't be found in the current context.

![image](https://cloud.githubusercontent.com/assets/12127/13908134/eba61a14-eeb9-11e5-9fd9-9dfae68c750d.png)


http://ward.asia.wiki.org/explore-transport-proxy.html