### PR TITLE
simplify reference styling

### DIFF
--- a/client/style.css
+++ b/client/style.css
@@ -380,19 +380,3 @@ textarea {
   opacity: 0.6;
   border-color: #eef2fe;
 }
-
-.reference {
-  background-color: #F0F8FF;
-  border-left: medium solid rgba(0, 180, 220, 0.5);
-  margin: 7px 0px 7px -10px;
-  padding: 7px;
-}
-
-.reference p {
-    margin-top: 3px;
-    margin-bottom: 3px;
-}
-
-.reference div {
-  margin-left: 20px;
-}

--- a/lib/reference.coffee
+++ b/lib/reference.coffee
@@ -16,7 +16,7 @@ emit = ($item, item) ->
   site = item.site
   resolve.resolveFrom site, ->
     $item.append """
-      <p style='margin-bottom:3px;'>
+      <p>
         <img class='remote'
           src='//#{site}/favicon.png'
           title='#{site}'
@@ -24,10 +24,9 @@ emit = ($item, item) ->
           data-slug="#{slug}"
         >
         #{resolve.resolveLinks "[[#{item.title or slug}]]"}
-      </p>
-      <div>
+        —
         #{resolve.resolveLinks(item.text)}
-      </div>
+      </p>
     """
 bind = ($item, item) ->
   $item.dblclick -> editor.textEditor $item, item


### PR DESCRIPTION
I'd like to make a page of References look a little better, more like natural text. We started coloring them so that one would see the first line and subsequent lines as one thing. Let's just merge subsequent lines onto the end of the first line so it does look like one thing even if not given any color treatment. 

![image](https://cloud.githubusercontent.com/assets/12127/13911119/6d01f00e-eee9-11e5-8e93-eb607311e4b7.png)
