### PR TITLE
guard against case where link has not been found

### DIFF
--- a/lib/refresh.coffee
+++ b/lib/refresh.coffee
@@ -294,7 +294,7 @@ cycle = ->
   createGhostPage = ->
     title = $("""a[href="/#{slug}.html"]:last""").text() or slug
     key = $("""a[href="/#{slug}.html"]:last""").parents('.page').data('key')
-    create = lineup.atKey(key).getCreate()
+    create = lineup.atKey(key)?.getCreate()
     #NEWPAGE future after failed pageHandler.get then buildPage
     pageObject = newPage()
     pageObject.setTitle(title)


### PR DESCRIPTION
Pull request #155 will pass the create action that made a page to the Future plugin when that link goes nowhere. Looking for the offending link is the search before the search.

With this commit we handle the case where the first search fails. A good example of where this happens is when one clicks on an axis label of the Radar chart.