### PR TITLE
update local sitemap on each put

### DIFF
--- a/lib/neighborhood.coffee
+++ b/lib/neighborhood.coffee
@@ -52,6 +52,23 @@ neighborhood.registerNeighbor = (site)->
   populateSiteInfoFor( site, neighborInfo )
   $('body').trigger 'new-neighbor', site
 
+neighborhood.updateSitemap = (pageObject)->
+  site = location.host
+  return unless neighborInfo = neighborhood.sites[site]
+  return if neighborInfo.sitemapRequestInflight
+  slug = pageObject.getSlug()
+  date = pageObject.getDate()
+  title = pageObject.getTitle()
+  synopsis = pageObject.getSynopsis()
+  entry = {slug, date, title, synopsis}
+  sitemap = neighborInfo.sitemap
+  index = sitemap.findIndex (slot) -> slot.slug == slug
+  if index >= 0
+    sitemap[index] = entry
+  else
+    sitemap.push entry
+  $('body').trigger 'new-neighbor-done', site
+
 neighborhood.listNeighbors = ()->
   _.keys( neighborhood.sites )
 

--- a/lib/page.coffee
+++ b/lib/page.coffee
@@ -5,6 +5,7 @@
 formatDate = require('./util').formatDate
 random = require './random'
 revision = require './revision'
+synopsis = require './synopsis'
 _ = require 'underscore'
 
 # http://pragprog.com/magazines/2011-08/decouple-your-apps-with-eventdriven-coffeescript
@@ -87,6 +88,13 @@ newPage = (json, site) ->
   getRevision = ->
     page.journal.length-1
 
+  getDate = ->
+    action = page.journal[getRevision()]
+    if action?
+      if action.date?
+        return action.date
+    return undefined
+
   getTimestamp = ->
     action = page.journal[getRevision()]
     if action?
@@ -96,6 +104,9 @@ newPage = (json, site) ->
         "Revision #{getRevision()}"
     else
       "Unrecorded Date"
+
+  getSynopsis = ->
+    synopsis page
 
   addItem = (item) ->
     item = _.extend {}, {id: random.itemId()}, item
@@ -172,6 +183,6 @@ newPage = (json, site) ->
     isCreate = (action) -> action.type == 'create'
     page.journal.reverse().find(isCreate)
 
-  {getRawPage, getContext, isPlugin, isRemote, isLocal, getRemoteSite, getRemoteSiteDetails, getSlug, getNeighbors, getTitle, setTitle, getRevision, getTimestamp, addItem, getItem, addParagraph, seqItems, seqActions, become, siteLineup, merge, apply, getCreate}
+  {getRawPage, getContext, isPlugin, isRemote, isLocal, getRemoteSite, getRemoteSiteDetails, getSlug, getNeighbors, getTitle, setTitle, getRevision, getDate, getTimestamp, getSynopsis, addItem, getItem, addParagraph, seqItems, seqActions, become, siteLineup, merge, apply, getCreate}
 
 module.exports = {newPage, asSlug, asTitle, pageEmitter}

--- a/lib/pageHandler.coffee
+++ b/lib/pageHandler.coffee
@@ -10,6 +10,7 @@ addToJournal = require './addToJournal'
 newPage = require('./page').newPage
 random = require './random'
 lineup = require './lineup'
+neighborhood = require './neighborhood'
 
 module.exports = pageHandler = {}
 
@@ -137,6 +138,7 @@ pushToServer = ($page, pagePutInfo, action) ->
     success: () ->
       # update pageObject (guard for tests)
       pageObject.apply action if pageObject?.apply
+      neighborhood.updateSitemap pageObject
       addToJournal $page.find('.journal'), action
       if action.type == 'fork' # push
         localStorage.removeItem $page.attr('id')


### PR DESCRIPTION
Search can't find pages that were just added to a site because the sitemap is out of date. This pull request updates the sitemap for the origin on each successful page put.

This inaccuracy is especially annoying for the Graph plugin when clicks create new pages without changing the color code, green should turn to blue. Here I added Random Page to the RSP graph and then clicked it. I was asked if I wanted to create the page. See that it has turned blue when I clicked the create button in the adjacent Future page.

![image](https://cloud.githubusercontent.com/assets/12127/14992940/5f833f90-111d-11e6-9102-8b63779c9633.png)
