### PR TITLE
size the action background gradient if it is other than expected

### DIFF
--- a/client/style.css
+++ b/client/style.css
@@ -160,6 +160,7 @@ footer {
 .action {
   font-size: 0.9em;
   background-color: #cccccc;
+  background-size: 24px 24px;
   color: #666666;
   text-align: center;
   text-decoration: none;


### PR DESCRIPTION
This addresses a long-standing limitation wherein journal action background gradients were assumed to be gradients and of the dimensions of generated gradients. (I waited for the avatar style backgrounds to go away and even created the Flagmatic plugin to offer some choice within federated wiki branding. But good content remains with poorly rendered backgrounds.)

Consider:
http://journal.hapgood.net/artwork-as-recipe.html

Before:
![image](https://cloud.githubusercontent.com/assets/12127/15456607/676e2172-202a-11e6-919e-feaf2e5d6888.png)

After:
![image](https://cloud.githubusercontent.com/assets/12127/15456608/7aff9a18-202a-11e6-9e1c-628b517d74ca.png)

Notice that even the generated gradients look better since they too are sized and rendered in full.
