### PR TITLE
static html, css improvements

### DIFF
--- a/client/style.css
+++ b/client/style.css
@@ -303,11 +303,13 @@ textarea {
 .clickable:hover {
   cursor: pointer; }
 
-@media all and (max-width: 400px) {
+@media all and (max-width: 490px) {
   .page {
-    width: 0.9%;
-    margin: 0.01%;
-    padding: 0.04%; } }
+    width: 1%;
+    margin: 8px;
+    padding: 0; }
+}
+
 ::-webkit-scrollbar {
   width: 10px;
   height: 10px;

--- a/views/static.html
+++ b/views/static.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html class='no-js'>
   <head>
-    <title>Smallest Federated Wiki</title>
+    <title>Federated Wiki</title>
     <meta content='text/html; charset=UTF-8' http-equiv='Content-Type'>
     <meta content='width=device-width, height=device-height, initial-scale=1.0, user-scalable=no' name='viewport'>
     <link id='favicon' href='/favicon.png' rel='icon' type='image/png'>
@@ -22,7 +22,11 @@
   <body>
     <section class='main'>
       {{#pages}}
-      <div class='page' id={{page}} {{{origin}}} {{{generated}}}>{{{story}}}</div>
+      <div class='page' id='{{page}}' {{{origin}}} {{{generated}}}>
+        <div class='paper'>
+          {{{story}}}
+        </div>
+      </div>
       {{/pages}}
     </section>
     <footer>


### PR DESCRIPTION
These are small changes that make display more consistent between narrow windows, small screens, and non-javascript tabs.

* Change title to Federated Wiki, omitting the word Smallest.
* Add div paper to static html to remove jarring visual effect on first load.
* Adjust thresholds and margins for smoother responsive behavior.