### PR TITLE
use proper title in .html version

### DIFF
--- a/views/static.html
+++ b/views/static.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html class='no-js'>
   <head>
-    <title>Federated Wiki</title>
+    <title>{{title}}</title>
     <meta content='text/html; charset=UTF-8' http-equiv='Content-Type'>
     <meta content='width=device-width, height=device-height, initial-scale=1.0, user-scalable=no' name='viewport'>
     <link id='favicon' href='/favicon.png' rel='icon' type='image/png'>


### PR DESCRIPTION
This pull request exploits the server improvements here:
https://github.com/fedwiki/wiki-server/pull/120

This will encourage other services to use the proper page title when referring to wiki pages, for example `Federated Timeline` instead of `Smallest Federated Wiki` in the example below. 

![image](https://cloud.githubusercontent.com/assets/12127/16823058/03daa724-4916-11e6-937c-ad0dbdb567dc.png)
