### PR TITLE
padding to stop jitter on button hover

### DIFF
--- a/client/style/style.css
+++ b/client/style/style.css
@@ -152,7 +152,7 @@ footer {
   clear: both;
   background-color: #eeeeee;
   overflow: auto;
-  /*padding: 3px; */
+  padding: 1px;
 }
 
 .action.fork {


### PR DESCRIPTION
Recent chrome browsers will inappropriately add a scrollbar to the journal upon hover over the the add or fork buttons when they are alone on the last line. (Firefox does not exhibit this unwanted behavior.)

![image](https://cloud.githubusercontent.com/assets/12127/21484531/f61b9dc2-cb48-11e6-8a8c-d353638c3ff9.png)

This case is easy to duplicate by retrieving from history a revision where this is true. 

The fix is to restore some padding that was removed with the introduction of the .paper div. This leaves room for the hover effects which must be of box dimensions that round differently between chrome and firefox.