### PR TITLE
ignore links with empty slugs

### DIFF
--- a/lib/resolve.coffee
+++ b/lib/resolve.coffee
@@ -38,7 +38,10 @@ resolve.resolveLinks = (string, sanitize=escape) ->
 
   internal = (match, name) ->
     slug = asSlug name
-    stash """<a class="internal" href="/#{slug}.html" data-page-name="#{slug}" title="#{resolve.resolutionContext.join(' => ')}">#{escape name}</a>"""
+    if slug.length
+      stash """<a class="internal" href="/#{slug}.html" data-page-name="#{slug}" title="#{resolve.resolutionContext.join(' => ')}">#{escape name}</a>"""
+    else
+      match
 
   external = (match, href, protocol, rest) ->
     stash """<a class="external" target="_blank" href="#{href}" title="#{href}" rel="nofollow">#{escape rest} <img src="/images/external-link-ltr-icon.png"></a>"""


### PR DESCRIPTION
We depend on slugs to give us case insensitivity. That is [[Welcome Visitors]] and [[welcome visitors]] link to the same page. We also get a sometimes unwanted insensitivity to all non-alphanumeric characters.

This pull request refuses to link to a title with no alphanumeric characters. This avoids the case where there the link slug would be empty. We don't yet consider the case where the slug is non-empty but stripped of useful identifying unicode characters.

![image](https://cloud.githubusercontent.com/assets/12127/21941162/4e55ff1e-d97c-11e6-9bc3-34ab7644689b.png)

This improvement based on conversation on matrix:
https://riot.im/app/#/room/#fedwiki:matrix.org/$14842628142654GcOwU:matrix.allmende.io