### PR TITLE
site adapter prototype

### DIFF
--- a/lib/addToJournal.coffee
+++ b/lib/addToJournal.coffee
@@ -22,8 +22,9 @@ module.exports = ($journal, action) ->
   else
     $action.appendTo($journal)
   if action.type == 'fork' and action.site?
+    url = wiki.site(action.site).url('favicon.png')
     $action
-      .css("background-image", "url(//#{action.site}/favicon.png)")
+      .css("background-image", "url(#{url})")
       .attr("href", "//#{action.site}/#{$page.attr('id')}.html")
       .attr("target", "#{action.site}")
       .data("site", action.site)

--- a/lib/addToJournal.coffee
+++ b/lib/addToJournal.coffee
@@ -22,10 +22,11 @@ module.exports = ($journal, action) ->
   else
     $action.appendTo($journal)
   if action.type == 'fork' and action.site?
-    url = wiki.site(action.site).url('favicon.png')
-    $action
-      .css("background-image", "url(#{url})")
-      .attr("href", "//#{action.site}/#{$page.attr('id')}.html")
-      .attr("target", "#{action.site}")
-      .data("site", action.site)
-      .data("slug", $page.attr('id'))
+    wiki.site(action.site).getURL 'favicon.png', (backgroundURL) ->
+      wiki.site(action.site).getURL "#{$page.attr('id')}.html", (forkedPage) ->
+        $action
+          .css("background-image", "url(#{backgroundURL})")
+          .attr("href", "#{forkedPage}")
+          .attr("target", "#{action.site}")
+          .data("site", action.site)
+          .data("slug", $page.attr('id'))

--- a/lib/addToJournal.coffee
+++ b/lib/addToJournal.coffee
@@ -4,6 +4,7 @@
 
 util = require './util'
 actionSymbols = require './actionSymbols'
+wiki = require './wiki'
 
 module.exports = ($journal, action) ->
   $page = $journal.parents('.page:first')

--- a/lib/addToJournal.coffee
+++ b/lib/addToJournal.coffee
@@ -4,7 +4,7 @@
 
 util = require './util'
 actionSymbols = require './actionSymbols'
-wiki = require './wiki'
+siteAdapter = require './siteAdapter'
 
 module.exports = ($journal, action) ->
   $page = $journal.parents('.page:first')
@@ -23,8 +23,8 @@ module.exports = ($journal, action) ->
   else
     $action.appendTo($journal)
   if action.type == 'fork' and action.site?
-    wiki.site(action.site).getURL 'favicon.png', (backgroundURL) ->
-      wiki.site(action.site).getURL "#{$page.attr('id')}.html", (forkedPage) ->
+    siteAdapter.site(action.site).getURL 'favicon.png', (backgroundURL) ->
+      siteAdapter.site(action.site).getURL "#{$page.attr('id')}.html", (forkedPage) ->
         $action
           .css("background-image", "url(#{backgroundURL})")
           .attr("href", "#{forkedPage}")

--- a/lib/factory.coffee
+++ b/lib/factory.coffee
@@ -50,8 +50,9 @@ emit = ($item, item) ->
   else if window.catalog?
     showMenu()
   else
-    $.getJSON '/system/factories.json', (data) ->
-      window.catalog = data
+    wiki.origin.get 'system/factories.json', (err, data) ->
+      console.error err if err
+      window.catalog = data || {}
       showMenu()
 
 bind = ($item, item) ->
@@ -77,7 +78,8 @@ bind = ($item, item) ->
     syncEditAction()
 
   addReference = (data) ->
-    $.getJSON "//#{data.site}/#{data.slug}.json", (remote) ->
+    wiki.site(data.site).get "#{data.slug}.json", (err, remote) ->
+      return punt err.msg if err
       item.type = 'reference'
       item.site = data.site
       item.slug = data.slug

--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -216,6 +216,7 @@ $ ->
 
 
   $ ->
+    console.log 'legacy - starting with first page refresh'
     state.first()
     $('.page').each refresh.cycle
     active.set($('.page').last())

--- a/lib/lineupActivity.coffee
+++ b/lib/lineupActivity.coffee
@@ -22,11 +22,12 @@ sparks = (journal) ->
 row = (page) ->
   remote = page.getRemoteSite location.host
   title = page.getTitle()
+  url = wiki.site(remote).url('favicion.png')
   """
     <tr><td align=right>
       #{sparks page.getRawPage().journal}
     <td>
-      <img class="remote" src="//#{remote}/favicon.png">
+      <img class="remote" src="#{url}">
       #{title}
   """
 

--- a/lib/lineupActivity.coffee
+++ b/lib/lineupActivity.coffee
@@ -1,6 +1,7 @@
 # Compare journal activity for pages in the current lineup.
 
 lineup = require './lineup'
+wiki = require './wiki'
 
 day = 24 * hour = 60 * minute = 60 * second = 1000
 

--- a/lib/lineupActivity.coffee
+++ b/lib/lineupActivity.coffee
@@ -22,7 +22,7 @@ sparks = (journal) ->
 row = (page) ->
   remote = page.getRemoteSite location.host
   title = page.getTitle()
-  url = wiki.site(remote).url('favicion.png')
+  url = wiki.site(remote).url('favicon.png')
   """
     <tr><td align=right>
       #{sparks page.getRawPage().journal}

--- a/lib/link.coffee
+++ b/lib/link.coffee
@@ -11,19 +11,19 @@ refresh = require './refresh'
 createPage = (name, loc) ->
   site = loc if loc and loc isnt 'view'
   title = asTitle(name)
-  url = wiki.site(site).url('favicon.png')
-  $page = $ """
-    <div class="page" id="#{name}">
-      <div class="paper">
-        <div class="twins"> <p> </p> </div>
-        <div class="header">
-          <h1> <img class="favicon" src="#{url}" height="32px"> #{title} </h1>
+  wiki.site(site).getURL 'favicon.png', (url) ->
+    $page = $ """
+      <div class="page" id="#{name}">
+        <div class="paper">
+          <div class="twins"> <p> </p> </div>
+          <div class="header">
+            <h1> <img class="favicon" src="#{url}" height="32px"> #{title} </h1>
+          </div>
         </div>
       </div>
-    </div>
-  """
-  $page.data('site', site) if site
-  $page
+    """
+    $page.data('site', site) if site
+    $page
 
 showPage = (name, loc) ->
   createPage(name, loc).appendTo('.main').each refresh.cycle

--- a/lib/link.coffee
+++ b/lib/link.coffee
@@ -6,6 +6,7 @@
 lineup = require './lineup'
 active = require './active'
 refresh = require './refresh'
+wiki = require './wiki'
 {asTitle, asSlug, pageEmitter} = require './page'
 
 createPage = (name, loc) ->

--- a/lib/link.coffee
+++ b/lib/link.coffee
@@ -6,13 +6,13 @@
 lineup = require './lineup'
 active = require './active'
 refresh = require './refresh'
-wiki = require './wiki'
+siteAdapter = require './siteAdapter'
 {asTitle, asSlug, pageEmitter} = require './page'
 
 createPage = (name, loc) ->
   site = loc if loc and loc isnt 'view'
   title = asTitle(name)
-  wiki.site(site).getURL 'favicon.png', (url) ->
+  siteAdapter.site(site).getURL 'favicon.png', (url) ->
     $page = $ """
       <div class="page" id="#{name}">
         <div class="paper">

--- a/lib/link.coffee
+++ b/lib/link.coffee
@@ -11,12 +11,13 @@ refresh = require './refresh'
 createPage = (name, loc) ->
   site = loc if loc and loc isnt 'view'
   title = asTitle(name)
+  url = wiki.site(site).url('favicon.png')
   $page = $ """
     <div class="page" id="#{name}">
       <div class="paper">
         <div class="twins"> <p> </p> </div>
         <div class="header">
-          <h1> <img class="favicon" src="#{ if site then "//#{site}" else "" }/favicon.png" height="32px"> #{title} </h1>
+          <h1> <img class="favicon" src="#{url}" height="32px"> #{title} </h1>
         </div>
       </div>
     </div>

--- a/lib/neighborhood.coffee
+++ b/lib/neighborhood.coffee
@@ -21,19 +21,14 @@ populateSiteInfoFor = (site,neighborInfo)->
       .addClass(to)
 
   fetchMap = ->
-    sitemapUrl = "//#{site}/system/sitemap.json"
     transition site, 'wait', 'fetch'
-    request = $.ajax
-      type: 'GET'
-      dataType: 'json'
-      url: sitemapUrl
-    request
-      .always( -> neighborInfo.sitemapRequestInflight = false )
-      .done (data)->
+    wiki.site(site).get 'system/sitemap.json', (err, data) ->
+      neighborInfo.sitemapRequestInflight = false
+      if !err
         neighborInfo.sitemap = data
         transition site, 'fetch', 'done'
         $('body').trigger 'new-neighbor-done', site
-      .fail (data)->
+      else
         transition site, 'fetch', 'fail'
 
   now = Date.now()

--- a/lib/neighborhood.coffee
+++ b/lib/neighborhood.coffee
@@ -3,7 +3,7 @@
 # slowly and keeps track of get requests in flight.
 
 _ = require 'underscore'
-wiki = require './wiki'
+siteAdapter = require './siteAdapter'
 
 module.exports = neighborhood = {}
 
@@ -23,7 +23,7 @@ populateSiteInfoFor = (site,neighborInfo)->
 
   fetchMap = ->
     transition site, 'wait', 'fetch'
-    return wiki.site(site).get 'system/sitemap.json', (err, data) ->
+    siteAdapter.site(site).get 'system/sitemap.json', (err, data) ->
       neighborInfo.sitemapRequestInflight = false
       if !err
         neighborInfo.sitemap = data

--- a/lib/neighborhood.coffee
+++ b/lib/neighborhood.coffee
@@ -3,6 +3,7 @@
 # slowly and keeps track of get requests in flight.
 
 _ = require 'underscore'
+wiki = require './wiki'
 
 module.exports = neighborhood = {}
 
@@ -22,7 +23,7 @@ populateSiteInfoFor = (site,neighborInfo)->
 
   fetchMap = ->
     transition site, 'wait', 'fetch'
-    wiki.site(site).get 'system/sitemap.json', (err, data) ->
+    return wiki.site(site).get 'system/sitemap.json', (err, data) ->
       neighborInfo.sitemapRequestInflight = false
       if !err
         neighborInfo.sitemap = data

--- a/lib/neighbors.coffee
+++ b/lib/neighbors.coffee
@@ -4,6 +4,7 @@
 # cause them to animate as an indication of work in progress.
 
 link = require './link'
+wiki = require './wiki'
 
 sites = null
 totalPages = 0
@@ -11,7 +12,8 @@ totalPages = 0
 
 flag = (site) ->
   # status class progression: .wait, .fetch, .fail or .done
-  wiki.site(site).getURL 'favicon.png', (url) ->
+  console.log "neighbors flag #{site}"
+  return wiki.site(site).getURL 'favicon.png', (url) ->
     """
       <span class="neighbor" data-site="#{site}">
         <div class="wait">
@@ -24,12 +26,23 @@ inject = (neighborhood) ->
   sites = neighborhood.sites
 
 bind = ->
+  console.log 'neighbors - bind'
   $neighborhood = $('.neighborhood')
   $('body')
     .on 'new-neighbor', (e, site) ->
-      $thisNeighborhood = $neighborhood
-      flag site, (siteFlag) ->
-        $thisNeighborhood.append siteFlag
+      console.log 'new-neighbor', site
+      wiki.site(site).getURL 'favicon.png', (url) ->
+        console.log 'appending', site, url
+        $neighborhood.append """
+          <span class="neighbor" data-site="#{site}">
+            <div class="wait">
+              <img src="#{url}" title="#{site}">
+            </div>
+          </span>
+        """
+#      flag site, (siteFlag) ->
+#        console.log 'neighbors - bind flag', siteFlag
+#        $neighborhood.append siteFlag
     .on 'new-neighbor-done', (e, site) ->
       pageCount = sites[site].sitemap.length
       img = $(""".neighborhood .neighbor[data-site="#{site}"]""").find('img')

--- a/lib/neighbors.coffee
+++ b/lib/neighbors.coffee
@@ -11,14 +11,14 @@ totalPages = 0
 
 flag = (site) ->
   # status class progression: .wait, .fetch, .fail or .done
-  url = wiki.site(site).url('favicon.png')
-  """
-    <span class="neighbor" data-site="#{site}">
-      <div class="wait">
-        <img src="#{url}" title="#{site}">
-      </div>
-    </span>
-  """
+  wiki.site(site).getURL 'favicon.png', (url) ->
+    """
+      <span class="neighbor" data-site="#{site}">
+        <div class="wait">
+          <img src="#{url}" title="#{site}">
+        </div>
+      </span>
+    """
 
 inject = (neighborhood) ->
   sites = neighborhood.sites
@@ -27,7 +27,9 @@ bind = ->
   $neighborhood = $('.neighborhood')
   $('body')
     .on 'new-neighbor', (e, site) ->
-      $neighborhood.append flag site
+      $thisNeighborhood = $neighborhood
+      flag site, (siteFlag) ->
+        $thisNeighborhood.append siteFlag
     .on 'new-neighbor-done', (e, site) ->
       pageCount = sites[site].sitemap.length
       img = $(""".neighborhood .neighbor[data-site="#{site}"]""").find('img')

--- a/lib/neighbors.coffee
+++ b/lib/neighbors.coffee
@@ -11,10 +11,11 @@ totalPages = 0
 
 flag = (site) ->
   # status class progression: .wait, .fetch, .fail or .done
+  url = wiki.site(site).url('favicon.png')
   """
     <span class="neighbor" data-site="#{site}">
       <div class="wait">
-        <img src="http://#{site}/favicon.png" title="#{site}">
+        <img src="#{url}" title="#{site}">
       </div>
     </span>
   """

--- a/lib/pageHandler.coffee
+++ b/lib/pageHandler.coffee
@@ -11,7 +11,7 @@ newPage = require('./page').newPage
 random = require './random'
 lineup = require './lineup'
 neighborhood = require './neighborhood'
-wiki = require './wiki'
+siteAdapter = require './siteAdapter'
 
 module.exports = pageHandler = {}
 
@@ -32,10 +32,10 @@ recursiveGet = ({pageInformation, whenGotten, whenNotGotten, localContext}) ->
 
   localBeforeOrigin = {
     get: (slug, done) ->
-      wiki.local.get slug, (err, page) ->
+      siteAdapter.local.get slug, (err, page) ->
         console.log [err, page]
         if err?
-          wiki.origin.get slug, done
+          siteAdapter.origin.get slug, done
         else
           site = 'local'
           done null, page
@@ -50,10 +50,10 @@ recursiveGet = ({pageInformation, whenGotten, whenNotGotten, localContext}) ->
   site = 'view' if site == null
 
   adapter = switch site
-    when 'local' then wiki.local
-    when 'origin' then wiki.origin
+    when 'local' then siteAdapter.local
+    when 'origin' then siteAdapter.origin
     when 'view' then localBeforeOrigin
-    else wiki.site(site)
+    else siteAdapter.site(site)
 
   adapter.get "#{slug}.json", (err, page) ->
     if !err

--- a/lib/pageHandler.coffee
+++ b/lib/pageHandler.coffee
@@ -11,6 +11,7 @@ newPage = require('./page').newPage
 random = require './random'
 lineup = require './lineup'
 neighborhood = require './neighborhood'
+wiki = require './wiki'
 
 module.exports = pageHandler = {}
 

--- a/lib/pageHandler.coffee
+++ b/lib/pageHandler.coffee
@@ -29,72 +29,62 @@ pageFromLocalStorage = (slug)->
 recursiveGet = ({pageInformation, whenGotten, whenNotGotten, localContext}) ->
   {slug,rev,site} = pageInformation
 
+  localBeforeOrigin = {
+    get: (slug, done) ->
+      wiki.local.get slug, (err, page) ->
+        console.log [err, page]
+        if err?
+          wiki.origin.get slug, done
+        else
+          site = 'local'
+          done null, page
+  }
+
   if site
     localContext = []
   else
     site = localContext.shift()
 
   site = 'origin' if site is window.location.host
-  site = null if site=='view'
+  site = 'view' if site == null
 
-  if site?
-    if site == 'local'
-      if localPage = pageFromLocalStorage(pageInformation.slug)
-        #NEWPAGE local from pageHandler.get
-        return whenGotten newPage(localPage, 'local' )
-      else
-        return whenNotGotten()
-    else
-      if site == 'origin'
-        url = "/#{slug}.json"
-      else
-        url = "//#{site}/#{slug}.json"
-  else
-    url = "/#{slug}.json"
+  adapter = switch site
+    when 'local' then wiki.local
+    when 'origin' then wiki.origin
+    when 'view' then localBeforeOrigin
+    else wiki.site(site)
 
-  $.ajax
-    type: 'GET'
-    dataType: 'json'
-    url: url + "?random=#{random.randomBytes(4)}"
-    success: (page) ->
+  adapter.get "#{slug}.json", (err, page) ->
+    if !err
+      console.log 'got', site, page
       page = revision.create rev, page if rev
-      #NEWPAGE server from pageHandler.get
-      return whenGotten newPage(page, site)
-    error: (xhr, type, msg) ->
-      if (xhr.status != 404) and (xhr.status != 0)
-        console.log 'pageHandler.get error', xhr, xhr.status, type, msg
-        #NEWPAGE trouble from PageHandler.get
-        troublePageObject = newPage {title: "Trouble: Can't Get Page"}, null
-        troublePageObject.addItem
-          type: 'html'
-          text: """
-The page handler has run into problems with this   request.
-<pre class=error>#{JSON.stringify pageInformation}</pre>
-The requested url.
-<pre class=error>#{url}</pre>
-The server reported status.
-<pre class=error>#{xhr.status}</pre>
-The error type.
-<pre class=error>#{type}</pre>
-The error message.
-<pre class=error>#{msg}</pre>
-These problems are rarely solved by reporting issues.
-There could be additional information reported in the browser's console.log.
-More information might be accessible by fetching the page outside of wiki.
-<a href="#{url}" target="_blank">try-now</a>
-"""
-        return whenGotten troublePageObject
-      if localContext.length > 0
-        recursiveGet( {pageInformation, whenGotten, whenNotGotten, localContext} )
+      whenGotten newPage(page, site)
+    else
+      if (err.xhr.status == 404) or (err.xhr.status == 0)
+        if localContext.length > 0
+          recursiveGet( {pageInformation, whenGotten, whenNotGotten, localContext} )
+        else
+          whenNotGotten()
       else
-        whenNotGotten()
+        text = """
+          The page handler has run into problems with this request.
+          <pre class=error>#{JSON.stringify pageInformation}</pre>
+          The requested url.
+          <pre class=error>#{url}</pre>
+          The server reported status.
+          <pre class=error>#{err.xhr?.status}</pre>
+          The error message.
+          <pre class=error>#{err.msg}</pre>
+          These problems are rarely solved by reporting issues.
+          There could be additional information reported in the browser's console.log.
+          More information might be accessible by fetching the page outside of wiki.
+          <a href="#{url}" target="_blank">try-now</a>
+        """
+        trouble = newPage {title: "Trouble: Can't Get Page"}, null
+        trouble.addItem {type:'html', text}
+        whenGotten trouble
 
 pageHandler.get = ({whenGotten,whenNotGotten,pageInformation}  ) ->
-
-  unless pageInformation.site
-    if localPage = pageFromLocalStorage(pageInformation.slug)
-      localPage = revision.create pageInformation.rev, localPage if pageInformation.rev
-      return whenGotten newPage( localPage, 'local' )
 
   pageHandler.context = ['view'] unless pageHandler.context.length
 

--- a/lib/reference.coffee
+++ b/lib/reference.coffee
@@ -6,6 +6,7 @@
 editor = require './editor'
 resolve = require './resolve'
 page = require './page'
+wiki = require './wiki'
 
 # see http://fed.wiki.org/about-reference-plugin.html
 

--- a/lib/reference.coffee
+++ b/lib/reference.coffee
@@ -14,11 +14,12 @@ emit = ($item, item) ->
   slug ||= page.asSlug item.title if item.title?
   slug ||= 'welcome-visitors'
   site = item.site
+  url = wiki.site(site).url('favicon.png')
   resolve.resolveFrom site, ->
     $item.append """
       <p>
         <img class='remote'
-          src='//#{site}/favicon.png'
+          src='#{url}'
           title='#{site}'
           data-site="#{site}"
           data-slug="#{slug}"

--- a/lib/reference.coffee
+++ b/lib/reference.coffee
@@ -14,21 +14,21 @@ emit = ($item, item) ->
   slug ||= page.asSlug item.title if item.title?
   slug ||= 'welcome-visitors'
   site = item.site
-  url = wiki.site(site).url('favicon.png')
-  resolve.resolveFrom site, ->
-    $item.append """
-      <p>
-        <img class='remote'
-          src='#{url}'
-          title='#{site}'
-          data-site="#{site}"
-          data-slug="#{slug}"
-        >
-        #{resolve.resolveLinks "[[#{item.title or slug}]]"}
-        —
-        #{resolve.resolveLinks(item.text)}
-      </p>
-    """
+  wiki.site(site).getURL 'favicon.png', (url) ->
+    resolve.resolveFrom site, ->
+      $item.append """
+        <p>
+          <img class='remote'
+            src='#{url}'
+            title='#{site}'
+            data-site="#{site}"
+            data-slug="#{slug}"
+          >
+          #{resolve.resolveLinks "[[#{item.title or slug}]]"}
+          —
+          #{resolve.resolveLinks(item.text)}
+        </p>
+      """
 bind = ($item, item) ->
   $item.dblclick -> editor.textEditor $item, item
 

--- a/lib/refresh.coffee
+++ b/lib/refresh.coffee
@@ -23,7 +23,7 @@ actionSymbols = require './actionSymbols'
 lineup = require './lineup'
 resolve = require './resolve'
 random = require './random'
-wiki = require './wiki'
+siteAdapter = require './siteAdapter'
 
 pageModule = require('./page')
 newPage = pageModule.newPage
@@ -145,7 +145,7 @@ handleHeaderClick = (e) ->
 emitHeader = ($header, $page, pageObject) ->
   remote = pageObject.getRemoteSite location.host
   tooltip = pageObject.getRemoteSiteDetails location.host
-  wiki.site(remote).getURL 'favicon.png', (url) ->
+  siteAdapter.site(remote).getURL 'favicon.png', (url) ->
     $header.append """
       <h1 title="#{tooltip}">
         <a href="#{pageObject.siteLineup()}" target="#{remote}">

--- a/lib/refresh.coffee
+++ b/lib/refresh.coffee
@@ -23,6 +23,7 @@ actionSymbols = require './actionSymbols'
 lineup = require './lineup'
 resolve = require './resolve'
 random = require './random'
+wiki = require './wiki'
 
 pageModule = require('./page')
 newPage = pageModule.newPage

--- a/lib/refresh.coffee
+++ b/lib/refresh.coffee
@@ -144,10 +144,11 @@ handleHeaderClick = (e) ->
 emitHeader = ($header, $page, pageObject) ->
   remote = pageObject.getRemoteSite location.host
   tooltip = pageObject.getRemoteSiteDetails location.host
+  url = wiki.site(remote).url('favicon.png')
   $header.append """
     <h1 title="#{tooltip}">
       <a href="#{pageObject.siteLineup()}" target="#{remote}">
-        <img src="//#{remote}/favicon.png" height="32px" class="favicon">
+        <img src="#{url}" height="32px" class="favicon">
       </a> #{resolve.escape pageObject.getTitle()}
     </h1>
   """
@@ -213,8 +214,9 @@ emitTwins = ($page) ->
         a.item.date < b.item.date
       flags = for {remoteSite, item}, i in bin
         break if i >= 8
+        url = wiki.site(remoteSite).url('favicon.png')
         """<img class="remote"
-          src="http://#{remoteSite}/favicon.png"
+          src="#{url}"
           data-slug="#{slug}"
           data-site="#{remoteSite}"
           title="#{remoteSite}">

--- a/lib/refresh.coffee
+++ b/lib/refresh.coffee
@@ -144,15 +144,15 @@ handleHeaderClick = (e) ->
 emitHeader = ($header, $page, pageObject) ->
   remote = pageObject.getRemoteSite location.host
   tooltip = pageObject.getRemoteSiteDetails location.host
-  url = wiki.site(remote).url('favicon.png')
-  $header.append """
-    <h1 title="#{tooltip}">
-      <a href="#{pageObject.siteLineup()}" target="#{remote}">
-        <img src="#{url}" height="32px" class="favicon">
-      </a> #{resolve.escape pageObject.getTitle()}
-    </h1>
-  """
-  $header.find('a').on 'click', handleHeaderClick
+  wiki.site(remote).getURL 'favicon.png', (url) ->
+    $header.append """
+      <h1 title="#{tooltip}">
+        <a href="#{pageObject.siteLineup()}" target="#{remote}">
+          <img src="#{url}" height="32px" class="favicon">
+        </a> #{resolve.escape pageObject.getTitle()}
+      </h1>
+    """
+    $header.find('a').on 'click', handleHeaderClick
 
 emitTimestamp = ($header, $page, pageObject) ->
   if $page.attr('id').match /_rev/

--- a/lib/siteAdapter.coffee
+++ b/lib/siteAdapter.coffee
@@ -1,0 +1,124 @@
+###
+Notes:
+url: needs to change to using a callback - if the correct form of url is not
+already known the code to determine the correct route is async...
+add getURL: (route, done) as a step forward...
+###
+
+module.exports = siteAdapter = {}
+
+sitePrefix = {}
+
+siteAdapter.local = {
+  url: (route) ->
+    "/#{route}?adapted"
+  getURL: (route, done) ->
+    done "/#{route}?adapted"
+  get: (route, done) ->
+    console.log 'wiki.local.get',route
+    if page = localStorage.getItem(route.replace(/\.json$/,''))
+      done null, JSON.parse page
+    else
+      done {msg: "no page named '#{route}' in browser local storage"}, null
+}
+
+siteAdapter.origin = {
+  url: (route) ->
+    "/#{route}?adapted"
+  getURL: (route, done) ->
+    done "/#{route}?adapted"
+  get: (route, done) ->
+    console.log 'wiki.origin.get',route
+    $.ajax
+      type: 'GET'
+      dataType: 'json'
+      url: this.url(route)
+      success: (page) -> done null, page
+      error: (xhr, type, msg) -> done {msg, xhr}, null
+}
+
+tryURL = (url, cb) ->
+  if not this.inuse
+    console.log "trying #{url}"
+    this.inuse = true
+    this.callback = cb
+    _that = this
+    this.img = new Image()
+    this.img.onload = () ->
+      _that.inuse = false
+      _that.callback(true)
+    this.img.onerror = (e) ->
+      if _that.inuse
+        console.log "tryURL onerror", e
+        _that.inuse = false
+        _that.callback(false)
+    this.start = new Date().getTime()
+    this.img.src = url
+    this.timer = setTimeout( () ->
+      if _that.inUse
+        _that.inUse = false
+        _that.callback(false)
+    , 1500)
+
+siteAdapter.site = (site) ->
+  return wiki.origin if !site or site == window.location.host
+  {
+    url: (route) ->
+      if sitePrefix[site]?
+        console.log "url - prefix ", sitePrefix[site]
+        "#{sitePrefix[site]}#{route}?adapted"
+      else
+        "//#{site}/#{route}?adapted"
+    getURL: (route, done) ->
+      if sitePrefix[site]?
+        console.log "getURL - prefix ", sitePrefix[site]
+        done "#{sitePrefix[site]}#{route}?adapted"
+
+      console.log "wiki.site(#{site}).getURL", route
+      testURL = "//#{site}/favicon.png"
+      tryURL testURL, (worked) ->
+        if worked
+          console.log "#{site} - same"
+          sitePrefix[site] = "//#{site}/"
+          console.log "  -  //#{site}/#{route}?adapted"
+          done "//#{site}/#{route}?adapted"
+        else
+          switch location.protocol
+            when 'http:'
+              testURL = "https://#{site}/favicon.png"
+              tryURL testURL, (worked) ->
+                if worked
+                  sitePrefix[site] = "https://#{site}/"
+                  console.log "  -  https://#{site}/#{route}?adapted"
+                  done "https://#{site}/#{route}?adapted"
+                else
+                  sitePrefix[site] = "//#{site}/"
+                  console.log "  -  //#{site}/#{route}?adapted"
+                  done "//#{site}/#{route}?adapted"
+            when 'https:'
+              testURL = "/proxy/#{site}/favicon.png"
+              tryURL testURL, (worked) ->
+                console.log "tried proxy", worked
+                if worked
+                  sitePrefix[site] = "/proxy/#{site}/"
+                  console.log "  -  /proxy/#{site}/#{route}?adapted"
+                  done "/proxy/#{site}/#{route}?adapted"
+                else
+                  sitePrefix[site] = "//#{site}/"
+                  console.log "  -  //#{site}/#{route}?adapted"
+                  done "//#{site}/#{route}?adapted"
+            else
+              console.log "#{site} - unavailable"
+              sitePrefix[site] = "//#{site}/"
+              console.log "  -  //#{site}/#{route}?adapted"
+              done "//#{site}/#{route}?adapted"
+    get: (route, done) ->
+      this.getURL route, (myURL) ->
+        console.log "wiki.site(#{site}).get",route, myURL
+        $.ajax
+          type: 'GET'
+          dataType: 'json'
+          url: myURL
+          success: (page) -> done null, page
+          error: (xhr, type, msg) -> done {msg, xhr}, null
+  }

--- a/lib/wiki.coffee
+++ b/lib/wiki.coffee
@@ -170,6 +170,6 @@ wiki.local = siteAdapter.local
 wiki.origin = siteAdapter.origin
 wiki.site = siteAdapter.site
 
-
+console.log "wiki global init done"
 
 module.exports = wiki

--- a/lib/wiki.coffee
+++ b/lib/wiki.coffee
@@ -168,9 +168,6 @@ wiki.createSynopsis = require('./synopsis') ##
 siteAdapter = require './siteAdapter'
 wiki.local = siteAdapter.local
 wiki.origin = siteAdapter.origin
-wiki.same = siteAdapter.same
-wiki.byProxy = siteAdapter.byProxy
-wiki.tls = siteAdapter.tls
 wiki.site = siteAdapter.site
 
 

--- a/lib/wiki.coffee
+++ b/lib/wiki.coffee
@@ -165,43 +165,14 @@ wiki.createSynopsis = require('./synopsis') ##
 
 # known use: (eventually all server directed xhr and some tags)
 
-wiki.local = {
-  url: -> wiki.origin.url
-  get: (route, done) ->
-    console.log 'wiki.local.get',route
-    if page = localStorage.getItem(route.replace(/\.json$/,''))
-      done null, JSON.parse page
-    else
-      done {msg: "no page named '#{route}' in browser local storage"}, null
-}
+siteAdapter = require './siteAdapter'
+wiki.local = siteAdapter.local
+wiki.origin = siteAdapter.origin
+wiki.same = siteAdapter.same
+wiki.byProxy = siteAdapter.byProxy
+wiki.tls = siteAdapter.tls
+wiki.site = siteAdapter.site
 
-wiki.origin = {
-  url: (route) ->
-    "/#{route}?adapted"
-  get: (route, done) ->
-    console.log 'wiki.origin.get',route
-    $.ajax
-      type: 'GET'
-      dataType: 'json'
-      url: this.url(route)
-      success: (page) -> done null, page
-      error: (xhr, type, msg) -> done {msg, xhr}, null
-}
-
-wiki.site = (site) ->
-  return wiki.origin if !site or site == window.location.host
-  {
-    url: (route) ->
-      "//#{site}/#{route}?adapted"
-    get: (route, done) ->
-      console.log 'wiki.site(site).get',route
-      $.ajax
-        type: 'GET'
-        dataType: 'json'
-        url: this.url(route)
-        success: (page) -> done null, page
-        error: (xhr, type, msg) -> done {msg, xhr}, null
-  }
 
 
 module.exports = wiki

--- a/lib/wiki.coffee
+++ b/lib/wiki.coffee
@@ -163,5 +163,45 @@ wiki.security = require './security'
 
 wiki.createSynopsis = require('./synopsis') ##
 
+# known use: (eventually all server directed xhr and some tags)
+
+wiki.local = {
+  url: -> wiki.origin.url
+  get: (route, done) ->
+    console.log 'wiki.local.get',route
+    if page = localStorage.getItem(route.replace(/\.json$/,''))
+      done null, JSON.parse page
+    else
+      done {msg: "no page named '#{route}' in browser local storage"}, null
+}
+
+wiki.origin = {
+  url: (route) ->
+    "/#{route}?adapted"
+  get: (route, done) ->
+    console.log 'wiki.origin.get',route
+    $.ajax
+      type: 'GET'
+      dataType: 'json'
+      url: this.url(route)
+      success: (page) -> done null, page
+      error: (xhr, type, msg) -> done {msg, xhr}, null
+}
+
+wiki.site = (site) ->
+  return wiki.origin if !site or site == window.location.host
+  {
+    url: (route) ->
+      "//#{site}/#{route}?adapted"
+    get: (route, done) ->
+      console.log 'wiki.site(site).get',route
+      $.ajax
+        type: 'GET'
+        dataType: 'json'
+        url: this.url(route)
+        success: (page) -> done null, page
+        error: (xhr, type, msg) -> done {msg, xhr}, null
+  }
+
 
 module.exports = wiki


### PR DESCRIPTION
This pull request introduces a family of "site adapters" which can compose and perform server facing operations. The prototype supports url-formatting and json-get from browser local storage and by the http protocol. The intention is that these can grow to support more network types and communication protocols, most urgently, https.

The wiki global provides three factories for creating lightweight adaptors.
- wiki.local
- wiki.origin
- wiki.site('fed.wiki.org')

Each adaptor supports (or will support) get, put and url formatting.
- url = wiki.origin.url 'favicon.png'
- wiki.origin.get 'welcome-visitors.json', (err, page) -> ...
- wiki.origin.put 'welcome-visitor/action', action, (err, reply) -> ...

The prototype temporarily adds `?adapted` to urls so that it is clear that requests observed in the browser have been issued through the adaptor mechanism.

![image](https://cloud.githubusercontent.com/assets/12127/22409683/dfba5658-e642-11e6-9f30-65fd37481891.png)

We anticipate each factory will be implemented in its own module and required into the wiki.coffee module or bootstrapped by some yet to be determined method.

The page handler get logic demonstrates how adapters can be composed for more complex behavior such as polling different adaptors for the presence of a desired page. See the `localBeforeOrigin` composite adapter.

We hope that this mechanism easily integrates with the @paul90's http/https adaptor work already in progress. It is my intention to hunt down remaining server facing ajax requests once we have established that this is a suitable direction for our combined work.