### PR TITLE
site adapter with a spot to patch wrong flags

### DIFF
--- a/lib/addToJournal.coffee
+++ b/lib/addToJournal.coffee
@@ -22,8 +22,9 @@ module.exports = ($journal, action) ->
   else
     $action.appendTo($journal)
   if action.type == 'fork' and action.site?
+    url = wiki.site(action.site).url('favicon.png')
     $action
-      .css("background-image", "url(//#{action.site}/favicon.png)")
+      .css("background-image", "url(#{url})")
       .attr("href", "//#{action.site}/#{$page.attr('id')}.html")
       .attr("target", "#{action.site}")
       .data("site", action.site)

--- a/lib/exportAdapter.coffee
+++ b/lib/exportAdapter.coffee
@@ -1,0 +1,28 @@
+# this adapter will read pages from an export file
+# hosted on a read only web server
+
+
+module.exports = exportAdapter = {}
+
+
+get = (urlx, done) ->
+  $.ajax
+    type: 'GET'
+    dataType: 'json'
+    url: urlx
+    contentType: 'application/json'
+    success: (data) -> done null, data
+    error: (xhr, type, msg) -> done {msg, xhr}, null
+
+
+exportAdapter.file = (loc) ->
+
+  url: (route) ->
+    switch route
+      when 'favicon.png' then '/favicon.png'
+
+  get: (route, done) ->
+    get loc, (err, pages) ->
+      if m = route.match /([a-z0-9-]\/).json/
+        done null, pages[m[1]]
+

--- a/lib/factory.coffee
+++ b/lib/factory.coffee
@@ -50,8 +50,9 @@ emit = ($item, item) ->
   else if window.catalog?
     showMenu()
   else
-    $.getJSON '/system/factories.json', (data) ->
-      window.catalog = data
+    wiki.origin.get 'system/factories.json', (err, data) ->
+      console.error err if err
+      window.catalog = data || {}
       showMenu()
 
 bind = ($item, item) ->
@@ -77,7 +78,8 @@ bind = ($item, item) ->
     syncEditAction()
 
   addReference = (data) ->
-    $.getJSON "//#{data.site}/#{data.slug}.json", (remote) ->
+    wiki.site(data.site).get "#{data.slug}.json", (err, remote) ->
+      return punt err.msg if err
       item.type = 'reference'
       item.site = data.site
       item.slug = data.slug

--- a/lib/lineupActivity.coffee
+++ b/lib/lineupActivity.coffee
@@ -22,11 +22,12 @@ sparks = (journal) ->
 row = (page) ->
   remote = page.getRemoteSite location.host
   title = page.getTitle()
+  url = wiki.site(remote).url('favicion.png')
   """
     <tr><td align=right>
       #{sparks page.getRawPage().journal}
     <td>
-      <img class="remote" src="//#{remote}/favicon.png">
+      <img class="remote" src="#{url}">
       #{title}
   """
 

--- a/lib/lineupActivity.coffee
+++ b/lib/lineupActivity.coffee
@@ -22,7 +22,7 @@ sparks = (journal) ->
 row = (page) ->
   remote = page.getRemoteSite location.host
   title = page.getTitle()
-  url = wiki.site(remote).url('favicion.png')
+  url = wiki.site(remote).url('favicon.png')
   """
     <tr><td align=right>
       #{sparks page.getRawPage().journal}

--- a/lib/link.coffee
+++ b/lib/link.coffee
@@ -11,12 +11,13 @@ refresh = require './refresh'
 createPage = (name, loc) ->
   site = loc if loc and loc isnt 'view'
   title = asTitle(name)
+  url = wiki.site(site).url('favicon.png')
   $page = $ """
     <div class="page" id="#{name}">
       <div class="paper">
         <div class="twins"> <p> </p> </div>
         <div class="header">
-          <h1> <img class="favicon" src="#{ if site then "//#{site}" else "" }/favicon.png" height="32px"> #{title} </h1>
+          <h1> <img class="favicon" src="#{url}" height="32px"> #{title} </h1>
         </div>
       </div>
     </div>

--- a/lib/neighborhood.coffee
+++ b/lib/neighborhood.coffee
@@ -21,19 +21,14 @@ populateSiteInfoFor = (site,neighborInfo)->
       .addClass(to)
 
   fetchMap = ->
-    sitemapUrl = "//#{site}/system/sitemap.json"
     transition site, 'wait', 'fetch'
-    request = $.ajax
-      type: 'GET'
-      dataType: 'json'
-      url: sitemapUrl
-    request
-      .always( -> neighborInfo.sitemapRequestInflight = false )
-      .done (data)->
+    wiki.site(site).get 'system/sitemap.json', (err, data) ->
+      neighborInfo.sitemapRequestInflight = false
+      if !err
         neighborInfo.sitemap = data
         transition site, 'fetch', 'done'
         $('body').trigger 'new-neighbor-done', site
-      .fail (data)->
+      else
         transition site, 'fetch', 'fail'
 
   now = Date.now()

--- a/lib/neighbors.coffee
+++ b/lib/neighbors.coffee
@@ -11,10 +11,11 @@ totalPages = 0
 
 flag = (site) ->
   # status class progression: .wait, .fetch, .fail or .done
+  url = wiki.site(site).url('favicon.png')
   """
     <span class="neighbor" data-site="#{site}">
       <div class="wait">
-        <img src="http://#{site}/favicon.png" title="#{site}">
+        <img src="#{url}" title="#{site}">
       </div>
     </span>
   """

--- a/lib/pageHandler.coffee
+++ b/lib/pageHandler.coffee
@@ -29,72 +29,62 @@ pageFromLocalStorage = (slug)->
 recursiveGet = ({pageInformation, whenGotten, whenNotGotten, localContext}) ->
   {slug,rev,site} = pageInformation
 
+  localBeforeOrigin = {
+    get: (slug, done) ->
+      wiki.local.get slug, (err, page) ->
+        console.log [err, page]
+        if err?
+          wiki.origin.get slug, done
+        else
+          site = 'local'
+          done null, page
+  }
+
   if site
     localContext = []
   else
     site = localContext.shift()
 
   site = 'origin' if site is window.location.host
-  site = null if site=='view'
+  site = 'view' if site == null
 
-  if site?
-    if site == 'local'
-      if localPage = pageFromLocalStorage(pageInformation.slug)
-        #NEWPAGE local from pageHandler.get
-        return whenGotten newPage(localPage, 'local' )
-      else
-        return whenNotGotten()
-    else
-      if site == 'origin'
-        url = "/#{slug}.json"
-      else
-        url = "//#{site}/#{slug}.json"
-  else
-    url = "/#{slug}.json"
+  adapter = switch site
+    when 'local' then wiki.local
+    when 'origin' then wiki.origin
+    when 'view' then localBeforeOrigin
+    else wiki.site(site)
 
-  $.ajax
-    type: 'GET'
-    dataType: 'json'
-    url: url + "?random=#{random.randomBytes(4)}"
-    success: (page) ->
+  adapter.get "#{slug}.json", (err, page) ->
+    if !err
+      console.log 'got', site, page
       page = revision.create rev, page if rev
-      #NEWPAGE server from pageHandler.get
-      return whenGotten newPage(page, site)
-    error: (xhr, type, msg) ->
-      if (xhr.status != 404) and (xhr.status != 0)
-        console.log 'pageHandler.get error', xhr, xhr.status, type, msg
-        #NEWPAGE trouble from PageHandler.get
-        troublePageObject = newPage {title: "Trouble: Can't Get Page"}, null
-        troublePageObject.addItem
-          type: 'html'
-          text: """
-The page handler has run into problems with this   request.
-<pre class=error>#{JSON.stringify pageInformation}</pre>
-The requested url.
-<pre class=error>#{url}</pre>
-The server reported status.
-<pre class=error>#{xhr.status}</pre>
-The error type.
-<pre class=error>#{type}</pre>
-The error message.
-<pre class=error>#{msg}</pre>
-These problems are rarely solved by reporting issues.
-There could be additional information reported in the browser's console.log.
-More information might be accessible by fetching the page outside of wiki.
-<a href="#{url}" target="_blank">try-now</a>
-"""
-        return whenGotten troublePageObject
-      if localContext.length > 0
-        recursiveGet( {pageInformation, whenGotten, whenNotGotten, localContext} )
+      whenGotten newPage(page, site)
+    else
+      if (err.xhr.status == 404) or (err.xhr.status == 0)
+        if localContext.length > 0
+          recursiveGet( {pageInformation, whenGotten, whenNotGotten, localContext} )
+        else
+          whenNotGotten()
       else
-        whenNotGotten()
+        text = """
+          The page handler has run into problems with this request.
+          <pre class=error>#{JSON.stringify pageInformation}</pre>
+          The requested url.
+          <pre class=error>#{url}</pre>
+          The server reported status.
+          <pre class=error>#{err.xhr?.status}</pre>
+          The error message.
+          <pre class=error>#{err.msg}</pre>
+          These problems are rarely solved by reporting issues.
+          There could be additional information reported in the browser's console.log.
+          More information might be accessible by fetching the page outside of wiki.
+          <a href="#{url}" target="_blank">try-now</a>
+        """
+        trouble = newPage {title: "Trouble: Can't Get Page"}, null
+        trouble.addItem {type:'html', text}
+        whenGotten trouble
 
 pageHandler.get = ({whenGotten,whenNotGotten,pageInformation}  ) ->
-
-  unless pageInformation.site
-    if localPage = pageFromLocalStorage(pageInformation.slug)
-      localPage = revision.create pageInformation.rev, localPage if pageInformation.rev
-      return whenGotten newPage( localPage, 'local' )
 
   pageHandler.context = ['view'] unless pageHandler.context.length
 

--- a/lib/reference.coffee
+++ b/lib/reference.coffee
@@ -14,11 +14,12 @@ emit = ($item, item) ->
   slug ||= page.asSlug item.title if item.title?
   slug ||= 'welcome-visitors'
   site = item.site
+  url = wiki.site(site).url('favicon.png')
   resolve.resolveFrom site, ->
     $item.append """
       <p>
         <img class='remote'
-          src='//#{site}/favicon.png'
+          src='#{url}'
           title='#{site}'
           data-site="#{site}"
           data-slug="#{slug}"

--- a/lib/refresh.coffee
+++ b/lib/refresh.coffee
@@ -144,10 +144,11 @@ handleHeaderClick = (e) ->
 emitHeader = ($header, $page, pageObject) ->
   remote = pageObject.getRemoteSite location.host
   tooltip = pageObject.getRemoteSiteDetails location.host
+  url = wiki.site(remote).url('favicon.png')
   $header.append """
     <h1 title="#{tooltip}">
       <a href="#{pageObject.siteLineup()}" target="#{remote}">
-        <img src="//#{remote}/favicon.png" height="32px" class="favicon">
+        <img src="#{url}" height="32px" class="favicon">
       </a> #{resolve.escape pageObject.getTitle()}
     </h1>
   """
@@ -213,8 +214,9 @@ emitTwins = ($page) ->
         a.item.date < b.item.date
       flags = for {remoteSite, item}, i in bin
         break if i >= 8
+        url = wiki.site(remoteSite).url('favicon.png')
         """<img class="remote"
-          src="http://#{remoteSite}/favicon.png"
+          src="#{url}"
           data-slug="#{slug}"
           data-site="#{remoteSite}"
           title="#{remoteSite}">

--- a/lib/siteAdapter.coffee
+++ b/lib/siteAdapter.coffee
@@ -91,3 +91,10 @@ factory = switch window?.location.protocol || 'http:'
 
 siteAdapter.site = (site) ->
   return adapters[site||host] || adapters[site] = factory(site)
+
+# here we add an experimental adapter that works by
+# completely different means, parsing a export file of pages
+
+exportAdapter = require './exportAdapter'
+adapters['oop.json'] = exportAdapter.file('http://c2.com/wiki/oop.json')
+

--- a/lib/siteAdapter.coffee
+++ b/lib/siteAdapter.coffee
@@ -1,0 +1,93 @@
+# The siteAdapter handles fetching resources from remote sites, including the
+# origin. It contains logic to check the correct protocol is used.
+
+module.exports = siteAdapter = {}
+
+# we'll use jquery for get and assume all gets are json
+# a site adapter need not use this helper if it has a better way
+
+get = (url, done) ->
+  $.ajax
+    type: 'GET'
+    dataType: 'json'
+    url: url
+    success: (data) -> done null, data
+    error: (xhr, type, msg) -> done {msg, xhr}, null
+
+put = (url, data, done) ->
+  $.ajax
+    type: 'PUT'
+    dataType: 'json'
+    url: url
+    processData: false
+    data: data
+    contentType: 'application/json'
+    success: (page) -> done null, page
+    error: (xhr, type, msg) -> done {msg, xhr}, null
+
+# we provide instant access to well known adapters where
+# there is no indecision as to how to address resources
+
+siteAdapter.local = {
+  url: (route) -> "/#{route}?adapted"
+  get: (route, done) ->
+    console.log 'wiki.local.get',route
+    if page = localStorage.getItem(route.replace(/\.json$/,''))
+      done null, JSON.parse page
+    else
+      done {msg: "no page named '#{route}' in browser local storage"}, null
+  put: (route, data, done) ->
+    # to be determined
+}
+
+siteAdapter.origin = {
+  url: (route) -> "/#{route}?adapted"
+  get: (route, done) -> get this.url(route), done
+  put: (route, data, done) -> # to be determined
+}
+
+# we provide alternatives that will be chosen and saved
+# for each remote site we encounter in the federation
+
+direct = (site) ->
+  url: (route) -> "//#{site}/#{route}?adapted"
+  get: (route, done) -> get this.url(route), done
+
+proxy = (site) ->
+  url: (route) -> "/proxy/#{site}/#{route}?adapted"
+  get: (route, done) -> get this.url(route), done
+
+# we can test whether a site supports ssl or not
+# for now we just delay a few milliseconds to simulate async logic
+# we return a temporary adapter for use while this test is in progress
+
+testForSSL = (site, done) ->
+  ding = -> done false
+  setTimmer ding, 200
+
+discover = (site) ->
+  testForSSL site, (ssl) ->
+    if ssl
+      adapter[site] = direct(site)
+      # rewrite dom objects to direct
+    else
+      adapter[site] = proxy(site)
+      # rewrite dom object to proxy
+  url: (route) -> "/proxy/#{site}/#{route}?adapted"
+  get: (route, done) -> get this.url(route), done
+
+# here is logic we use to dynamically choose an adapter
+# for a remote site. Our strategy depends on the protocol
+# in use by the origin with useful defaults for testing
+
+adapters = {}
+
+host = window?.location.host || 'localhost'
+adapters[host] = siteAdapter.origin
+
+factory = switch window?.location.protocol || 'http:'
+  when 'http:' then direct
+  when 'https:' then discover
+
+siteAdapter.site = (site) ->
+  return adapters[site||host] || adapters[site] = factory(site)

--- a/lib/wiki.coffee
+++ b/lib/wiki.coffee
@@ -163,5 +163,45 @@ wiki.security = require './security'
 
 wiki.createSynopsis = require('./synopsis') ##
 
+# known use: (eventually all server directed xhr and some tags)
+
+wiki.local = {
+  url: -> wiki.origin.url
+  get: (route, done) ->
+    console.log 'wiki.local.get',route
+    if page = localStorage.getItem(route.replace(/\.json$/,''))
+      done null, JSON.parse page
+    else
+      done {msg: "no page named '#{route}' in browser local storage"}, null
+}
+
+wiki.origin = {
+  url: (route) ->
+    "/#{route}?adapted"
+  get: (route, done) ->
+    console.log 'wiki.origin.get',route
+    $.ajax
+      type: 'GET'
+      dataType: 'json'
+      url: this.url(route)
+      success: (page) -> done null, page
+      error: (xhr, type, msg) -> done {msg, xhr}, null
+}
+
+wiki.site = (site) ->
+  return wiki.origin if !site or site == window.location.host
+  {
+    url: (route) ->
+      "//#{site}/#{route}?adapted"
+    get: (route, done) ->
+      console.log 'wiki.site(site).get',route
+      $.ajax
+        type: 'GET'
+        dataType: 'json'
+        url: this.url(route)
+        success: (page) -> done null, page
+        error: (xhr, type, msg) -> done {msg, xhr}, null
+  }
+
 
 module.exports = wiki

--- a/lib/wiki.coffee
+++ b/lib/wiki.coffee
@@ -165,43 +165,9 @@ wiki.createSynopsis = require('./synopsis') ##
 
 # known use: (eventually all server directed xhr and some tags)
 
-wiki.local = {
-  url: -> wiki.origin.url
-  get: (route, done) ->
-    console.log 'wiki.local.get',route
-    if page = localStorage.getItem(route.replace(/\.json$/,''))
-      done null, JSON.parse page
-    else
-      done {msg: "no page named '#{route}' in browser local storage"}, null
-}
-
-wiki.origin = {
-  url: (route) ->
-    "/#{route}?adapted"
-  get: (route, done) ->
-    console.log 'wiki.origin.get',route
-    $.ajax
-      type: 'GET'
-      dataType: 'json'
-      url: this.url(route)
-      success: (page) -> done null, page
-      error: (xhr, type, msg) -> done {msg, xhr}, null
-}
-
-wiki.site = (site) ->
-  return wiki.origin if !site or site == window.location.host
-  {
-    url: (route) ->
-      "//#{site}/#{route}?adapted"
-    get: (route, done) ->
-      console.log 'wiki.site(site).get',route
-      $.ajax
-        type: 'GET'
-        dataType: 'json'
-        url: this.url(route)
-        success: (page) -> done null, page
-        error: (xhr, type, msg) -> done {msg, xhr}, null
-  }
-
+siteAdapter = require './siteAdapter'
+wiki.local = siteAdapter.local
+wiki.origin = siteAdapter.origin
+wiki.site = siteAdapter.site
 
 module.exports = wiki


### PR DESCRIPTION
With this version I try to manage the case analysis and leave room for patching up flags that are not properly generated with the sync url function.

Missing code is marked with comments.

I've added an adapter that can serve pages out of an export file. I haven't tested this yet because I had trouble setting cors headers on readily available servers. Damn apache config.