### PR TITLE
site adapter prototype - just flag and get

### DIFF
--- a/lib/addToJournal.coffee
+++ b/lib/addToJournal.coffee
@@ -23,7 +23,7 @@ module.exports = ($journal, action) ->
     $action.appendTo($journal)
   if action.type == 'fork' and action.site?
     $action
-      .css("background-image", "url(//#{action.site}/favicon.png)")
+      .css("background-image", "url(#{wiki.site(action.site).flag()}")
       .attr("href", "//#{action.site}/#{$page.attr('id')}.html")
       .attr("target", "#{action.site}")
       .data("site", action.site)

--- a/lib/addToJournal.coffee
+++ b/lib/addToJournal.coffee
@@ -24,7 +24,7 @@ module.exports = ($journal, action) ->
   if action.type == 'fork' and action.site?
     $action
       .css("background-image", "url(#{wiki.site(action.site).flag()}")
-      .attr("href", "//#{action.site}/#{$page.attr('id')}.html")
+      .attr("href", "#{wiki.site(action.site).getURL($page.attr('id'))}.html")
       .attr("target", "#{action.site}")
       .data("site", action.site)
       .data("slug", $page.attr('id'))

--- a/lib/factory.coffee
+++ b/lib/factory.coffee
@@ -50,7 +50,8 @@ emit = ($item, item) ->
   else if window.catalog?
     showMenu()
   else
-    wiki.origin.get '/system/factories.json', (data) ->
+    wiki.origin.get 'system/factories.json', (error, data) ->
+      console.log 'factory', data
       window.catalog = data
       showMenu()
 

--- a/lib/factory.coffee
+++ b/lib/factory.coffee
@@ -50,7 +50,7 @@ emit = ($item, item) ->
   else if window.catalog?
     showMenu()
   else
-    $.getJSON '/system/factories.json', (data) ->
+    wiki.origin.get '/system/factories.json', (data) ->
       window.catalog = data
       showMenu()
 
@@ -77,7 +77,7 @@ bind = ($item, item) ->
     syncEditAction()
 
   addReference = (data) ->
-    $.getJSON "//#{data.site}/#{data.slug}.json", (remote) ->
+    wiki.site(data.site).get "#{data-slug}.json", (remote) ->
       item.type = 'reference'
       item.site = data.site
       item.slug = data.slug

--- a/lib/lineupActivity.coffee
+++ b/lib/lineupActivity.coffee
@@ -26,7 +26,7 @@ row = (page) ->
     <tr><td align=right>
       #{sparks page.getRawPage().journal}
     <td>
-      <img class="remote" src="//#{remote}/favicon.png">
+      <img class="remote" src="#{wiki.site(remote).flag()}">
       #{title}
   """
 

--- a/lib/link.coffee
+++ b/lib/link.coffee
@@ -16,7 +16,7 @@ createPage = (name, loc) ->
       <div class="paper">
         <div class="twins"> <p> </p> </div>
         <div class="header">
-          <h1> <img class="favicon" src="#{ if site then "//#{site}" else "" }/favicon.png" height="32px"> #{title} </h1>
+          <h1> <img class="favicon" src="#{wiki.site(site).flag()}" height="32px"> #{title} </h1>
         </div>
       </div>
     </div>

--- a/lib/neighborhood.coffee
+++ b/lib/neighborhood.coffee
@@ -21,19 +21,14 @@ populateSiteInfoFor = (site,neighborInfo)->
       .addClass(to)
 
   fetchMap = ->
-    sitemapUrl = "//#{site}/system/sitemap.json"
     transition site, 'wait', 'fetch'
-    request = $.ajax
-      type: 'GET'
-      dataType: 'json'
-      url: sitemapUrl
-    request
-      .always( -> neighborInfo.sitemapRequestInflight = false )
-      .done (data)->
+    wiki.site(site).get 'system/sitemap.json', (err, data) ->
+      neighborInfo.sitemapRequestInflight = false
+      if !err
         neighborInfo.sitemap = data
         transition site, 'fetch', 'done'
         $('body').trigger 'new-neighbor-done', site
-      .fail (data)->
+      else
         transition site, 'fetch', 'fail'
 
   now = Date.now()

--- a/lib/neighbors.coffee
+++ b/lib/neighbors.coffee
@@ -11,10 +11,11 @@ totalPages = 0
 
 flag = (site) ->
   # status class progression: .wait, .fetch, .fail or .done
+  console.log 'neighbor - flag'
   """
     <span class="neighbor" data-site="#{site}">
       <div class="wait">
-        <img src="http://#{site}/favicon.png" title="#{site}">
+        <img src="#{wiki.site(site).flag()}" title="#{site}">
       </div>
     </span>
   """

--- a/lib/page.coffee
+++ b/lib/page.coffee
@@ -155,7 +155,8 @@ newPage = (json, site) ->
     else
       "view/welcome-visitors/view/#{slug}"
     if isRemote()
-      "//#{site}/#{path}"
+      # "//#{site}/#{path}"
+      wiki.site(site).getURL(path)
     else
       "/#{path}"
 

--- a/lib/pageHandler.coffee
+++ b/lib/pageHandler.coffee
@@ -29,65 +29,61 @@ pageFromLocalStorage = (slug)->
 recursiveGet = ({pageInformation, whenGotten, whenNotGotten, localContext}) ->
   {slug,rev,site} = pageInformation
 
+  localBeforeOrigin = {
+    get: (slug, done) ->
+      wiki.local.get slug, (err, page) ->
+        console.log [err, page]
+        if err?
+          wiki.origin.get slug, done
+        else
+          site = 'local'
+          done null, page
+  }
+
   if site
     localContext = []
   else
     site = localContext.shift()
 
   site = 'origin' if site is window.location.host
-  site = null if site=='view'
+  site = 'view' if site == null
 
-  if site?
-    if site == 'local'
-      if localPage = pageFromLocalStorage(pageInformation.slug)
-        #NEWPAGE local from pageHandler.get
-        return whenGotten newPage(localPage, 'local' )
-      else
-        return whenNotGotten()
-    else
-      if site == 'origin'
-        url = "/#{slug}.json"
-      else
-        url = "//#{site}/#{slug}.json"
-  else
-    url = "/#{slug}.json"
+  adapter = switch site
+    when 'local' then wiki.local
+    when 'origin' then wiki.origin
+    when 'view' then localBeforeOrigin
+    else wiki.site(site)
 
-  $.ajax
-    type: 'GET'
-    dataType: 'json'
-    url: url + "?random=#{random.randomBytes(4)}"
-    success: (page) ->
+  adapter.get "#{slug}.json", (err, page) ->
+    if !err
+      console.log 'got', site, page
       page = revision.create rev, page if rev
-      #NEWPAGE server from pageHandler.get
-      return whenGotten newPage(page, site)
-    error: (xhr, type, msg) ->
-      if (xhr.status != 404) and (xhr.status != 0)
-        console.log 'pageHandler.get error', xhr, xhr.status, type, msg
-        #NEWPAGE trouble from PageHandler.get
-        troublePageObject = newPage {title: "Trouble: Can't Get Page"}, null
-        troublePageObject.addItem
-          type: 'html'
-          text: """
-The page handler has run into problems with this   request.
-<pre class=error>#{JSON.stringify pageInformation}</pre>
-The requested url.
-<pre class=error>#{url}</pre>
-The server reported status.
-<pre class=error>#{xhr.status}</pre>
-The error type.
-<pre class=error>#{type}</pre>
-The error message.
-<pre class=error>#{msg}</pre>
-These problems are rarely solved by reporting issues.
-There could be additional information reported in the browser's console.log.
-More information might be accessible by fetching the page outside of wiki.
-<a href="#{url}" target="_blank">try-now</a>
-"""
-        return whenGotten troublePageObject
-      if localContext.length > 0
-        recursiveGet( {pageInformation, whenGotten, whenNotGotten, localContext} )
+      whenGotten newPage(page, site)
+    else
+      if (err.xhr.status == 404) or (err.xhr.status == 0)
+        if localContext.length > 0
+          recursiveGet( {pageInformation, whenGotten, whenNotGotten, localContext} )
+        else
+          whenNotGotten()
       else
-        whenNotGotten()
+        text = """
+          The page handler has run into problems with this request.
+          <pre class=error>#{JSON.stringify pageInformation}</pre>
+          The requested url.
+          <pre class=error>#{url}</pre>
+          The server reported status.
+          <pre class=error>#{err.xhr?.status}</pre>
+          The error message.
+          <pre class=error>#{err.msg}</pre>
+          These problems are rarely solved by reporting issues.
+          There could be additional information reported in the browser's console.log.
+          More information might be accessible by fetching the page outside of wiki.
+          <a href="#{url}" target="_blank">try-now</a>
+        """
+        trouble = newPage {title: "Trouble: Can't Get Page"}, null
+        trouble.addItem {type:'html', text}
+        whenGotten trouble
+
 
 pageHandler.get = ({whenGotten,whenNotGotten,pageInformation}  ) ->
 

--- a/lib/pageHandler.coffee
+++ b/lib/pageHandler.coffee
@@ -126,9 +126,9 @@ pushToServer = ($page, pagePutInfo, action) ->
   if action.type == 'fork'
     bundle.item = deepCopy pageObject.getRawPage()
 
-  wiki.origin.put pagePutInfo.slug, bundle, (error) ->
-    if error
-      action.error = {error.type, error.msg, response: error.xhr.responseText}
+  wiki.origin.put pagePutInfo.slug, bundle, (err) ->
+    if err
+      action.error = { type: err.type, msg: err.msg, response: err.xhr.responseText}
       pushToLocal $page, pagePutInfo, action
     else
       pageObject.apply action if pageObject?.apply

--- a/lib/reference.coffee
+++ b/lib/reference.coffee
@@ -18,7 +18,7 @@ emit = ($item, item) ->
     $item.append """
       <p>
         <img class='remote'
-          src='//#{site}/favicon.png'
+          src='#{wiki.site(site).flag()}'
           title='#{site}'
           data-site="#{site}"
           data-slug="#{slug}"

--- a/lib/refresh.coffee
+++ b/lib/refresh.coffee
@@ -147,7 +147,7 @@ emitHeader = ($header, $page, pageObject) ->
   $header.append """
     <h1 title="#{tooltip}">
       <a href="#{pageObject.siteLineup()}" target="#{remote}">
-        <img src="//#{remote}/favicon.png" height="32px" class="favicon">
+        <img src="#{wiki.site(remote).flag()}" height="32px" class="favicon">
       </a> #{resolve.escape pageObject.getTitle()}
     </h1>
   """
@@ -214,7 +214,7 @@ emitTwins = ($page) ->
       flags = for {remoteSite, item}, i in bin
         break if i >= 8
         """<img class="remote"
-          src="http://#{remoteSite}/favicon.png"
+          src="#{wiki.site(remoteSite).flag()}"
           data-slug="#{slug}"
           data-site="#{remoteSite}"
           title="#{remoteSite}">

--- a/lib/refresh.coffee
+++ b/lib/refresh.coffee
@@ -179,7 +179,7 @@ emitFooter = ($footer, pageObject) ->
   $footer.append """
     <a id="license" href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank">CC BY-SA 4.0</a> .
     <a class="show-page-source" href="/#{slug}.json?random=#{random.randomBytes(4)}" title="source">JSON</a> .
-    <a href= "//#{host}/#{slug}.html" target="#{host}">#{host} </a> .
+    <a href= "#{wiki.site(host).getURL(slug)}.html" date-slug="#{slug}" target="#{host}">#{host} </a> .
     <a href= "#" class=search>search</a>
   """
 

--- a/lib/refresh.coffee
+++ b/lib/refresh.coffee
@@ -137,7 +137,10 @@ handleHeaderClick = (e) ->
     $page = $(e.target).parents('.page:first')
     crumbs = lineup.crumbs $page.data('key'), location.host
     [target, ] = crumbs
-    newWindow = window.open "//#{crumbs.join '/'}", target
+    [prefix, ] = wiki.site(target).getURL('').split('/')
+    if prefix is ''
+      prefix = window.location.protocol
+    newWindow = window.open "#{prefix}//#{crumbs.join '/'}", target
     newWindow.focus()
 
 
@@ -178,7 +181,7 @@ emitFooter = ($footer, pageObject) ->
   slug = pageObject.getSlug()
   $footer.append """
     <a id="license" href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank">CC BY-SA 4.0</a> .
-    <a class="show-page-source" href="/#{slug}.json?random=#{random.randomBytes(4)}" title="source">JSON</a> .
+    <a class="show-page-source" href="#{wiki.site(host).getURL(slug)}.json?random=#{random.randomBytes(4)}" title="source">JSON</a> .
     <a href= "#{wiki.site(host).getURL(slug)}.html" date-slug="#{slug}" target="#{host}">#{host} </a> .
     <a href= "#" class=search>search</a>
   """

--- a/lib/siteAdapter.coffee
+++ b/lib/siteAdapter.coffee
@@ -79,6 +79,13 @@ siteAdapter.local = {
       done null, JSON.parse page
     else
       done {msg: "no page named '#{route}' in browser local storage"}
+  put: (route, data, done) ->
+    console.log "wiki.local.put #{route}"
+    localStorage.setItem(route, JSON.stringify(data))
+    done()
+  delete: (route) ->
+    console.log "wiki.local.delete #{route}"
+    localStorage.removeItem route
 }
 
 siteAdapter.origin = {
@@ -92,6 +99,16 @@ siteAdapter.origin = {
       url: "/#{route}?adapted"
       success: (page) -> done null, page
       error: (xhr, type, msg) -> done {msg, xhr}, null
+  put: (route, data, done) ->
+    console.log "wiki.orgin.put #{route}"
+    $.ajax
+      type: 'PUT'
+      url: "/page/#{route}/action"
+      data:
+        'action': JSON.stringify(data)
+      success: () -> done null
+      error: (xhr, type, msg) -> done {xhr, type, msg}
+
 }
 
 siteAdapter.site = (site) ->

--- a/lib/siteAdapter.coffee
+++ b/lib/siteAdapter.coffee
@@ -72,6 +72,7 @@ findAdapter = (site) ->
 
 siteAdapter.local = {
   flag: -> "/favicon.png?adapted"
+  getURL: (route) -> "/#{route}"
   get: (route, done) ->
     console.log "wiki.local.get #{route}"
     if page = localStorage.getItem(route.replace(/\.json$/,''))
@@ -82,6 +83,7 @@ siteAdapter.local = {
 
 siteAdapter.origin = {
   flag: -> "/favicon.png?adapted"
+  getURL: (route) -> "/#{route}"
   get: (route, done) ->
     console.log "wiki.origin.get #{route}"
     $.ajax
@@ -156,6 +158,35 @@ siteAdapter.site = (site) ->
         tempFlags[site] = tempFlag
         tempFlag
 
+    getURL: (route) ->
+      if sitePrefix[site]?
+        if sitePrefix[site] is ""
+          console.log "#{site} is unreachable, can't link to #{route}"
+          ""
+        else
+          if /proxy/.test(sitePrefix[site])
+            thisSite = sitePrefix[site].substring(7)
+            thisPrefix = "http://#{thisSite}"
+          else
+            thisPrefix = sitePrefix[site]
+          "#{thisPrefix}/#{route}"
+      else
+        # don't yet know how to construct links for site, so find how and fixup
+        findAdapter(site).prefix (prefix) ->
+          if prefix is ""
+            console.log "#{site} is unreachable"
+          else
+            console.log "Prefix for #{site} is #{prefix}, about to fixup links"
+            # add href to journal fork
+            $('a[target="' + site + '"]').each( () ->
+              if /proxy/.test(prefix)
+                thisSite = prefix.substring(7)
+                thisPrefix = "http://#{thisSite}"
+              else
+                thisPrefix = prefix
+              $(this).attr('href', "#{thisPrefix}/#{$(this).data("slug")}.html") )
+        ""
+
     get: (route, done) ->
       if sitePrefix[site]?
         if sitePrefix[site] is ""
@@ -171,7 +202,7 @@ siteAdapter.site = (site) ->
             error: (xhr, type, msg) -> done {msg, xhr}, null
       else
         findAdapter(site).prefix (prefix) ->
-          if sitePrefix[site] is ""
+          if prefix is ""
             console.log "#{site} is unreachable"
             done {"#{site} is unreachable"}, null
           else

--- a/lib/siteAdapter.coffee
+++ b/lib/siteAdapter.coffee
@@ -11,32 +11,64 @@ sitePrefix = {}
 # we know how to get a site's flag
 tempFlags = {}
 
-createTempFlag = (site) ->
-  console.log "creating temp flags for #{site}"
-  myCanvas = document.createElement('canvas')
-  myCanvas.width = 32
-  myCanvas.height = 32
+findAdapter = (site) ->
+  test: (url, done) ->
+    this.inuse = true
+    this.callback = done
+    _that = this
+    this.img = new Image()
+    this.img.onload = () ->
+      _that.inuse = false
+      _that.callback(true)
+    this.img.onerror = (e) ->
+      if _that.inuse
+        _that.inuse = false
+        _that.callback(false)
+    this.start = new Date().getTime()
+    this.img.src = url
+    this.timer =setTimeout( () ->
+      if _that.inuse
+        _that.inuse = false
+        _that.callback(false)
+    , 1500)
 
-  ctx = myCanvas.getContext('2d')
+  prefix: (done) ->
+    console.log "findPrefix for #{site}"
+    if sitePrefix[site]?
+      done sitePrefix[site]
 
-  x1 = Math.random() * 32
-  y1 = x1
-  y2 = Math.random() * 32
-  x2 = 32 - y2
-
-  c1 = (Math.random() * 0xFF<<0).toString(16)
-  c2 = (Math.random() * 0xFF<<0).toString(16)
-
-  color1 = '#' + c1 + c1 + c1
-  color2 = '#' + c2 + c2 + c2
-
-
-  gradient = ctx.createRadialGradient(x1,y1,32,x2,y2,0)
-  gradient.addColorStop(0, color1)
-  gradient.addColorStop(1, color2)
-  ctx.fillStyle = gradient
-  ctx.fillRect(0,0,32,32)
-  myCanvas.toDataURL()
+    testURL = "//#{site}/favicon.png"
+    this.test testURL, (worked) ->
+      if worked
+        sitePrefix[site] = "//#{site}"
+        done "//#{site}"
+      else
+        switch location.protocol
+          when 'http:'
+            testURL = "https://#{site}/favicon.png"
+            this.test testURL, (worked) ->
+              if worked
+                sitePrefix[site] = "https://#{site}"
+                done "https://#{site}"
+              else
+                #
+                sitePrefix[site] = "//#{site}"
+                done "//#{site}"
+          when 'https:'
+            testURL = "/proxy/#{site}/favicon.png"
+            this.test testURL, (worked) ->
+              if worked
+                sitePrefix[site] = "/proxy/#{site}"
+                done "/proxy/#{site}"
+              else
+                #
+                sitePrefix[site] = "//#{site}"
+                done "//#{site}"
+          else
+            # if we are here we have a different the origin on a different protocol
+            # maybe we should try https and http, but that's for later...
+            sitePrefix[site] = "//#{site}"
+            done "//#{site}"
 
 siteAdapter.local = {
   flag: -> "/favicon.png?adapted"
@@ -63,24 +95,60 @@ siteAdapter.origin = {
 siteAdapter.site = (site) ->
   return siteAdapter.origin if !site or site is window.location.host
 
-  flag: ->
-    console.log "wiki.site(#{site}.flag)"
-    if sitePrefix[site]?
-      # we already know how to construct flag url
-      console.log "wiki.site(#{site}).flag - sitePrefix[site]"
-      sitePrefix[site] + "favicon.png?adapted"
-    else if tempFlags[site]?
-      # we already have a temp. flag
-      console.log "wiki.site(#{site}).flag - have temp. flag"
-      tempFlags[site]
-    else
-      # we don't know the url to the real flag, or have a temp flag
-      #findPrefix site, (prefix) ->
-      #  console.log "Prefix for #{site} is #{prefix}"
+  createTempFlag = (site) ->
+    console.log "creating temp flags for #{site}"
+    myCanvas = document.createElement('canvas')
+    myCanvas.width = 32
+    myCanvas.height = 32
 
-      # create a temp flag, save it for reuse, and return it
-      tempFlag = createTempFlag(site)
-      tempFlags[site] = tempFlag
-      tempFlag
+    ctx = myCanvas.getContext('2d')
 
-  get: (route, cb) ->
+    x1 = Math.random() * 32
+    y1 = x1
+    y2 = Math.random() * 32
+    x2 = 32 - y2
+
+    c1 = (Math.random() * 0xFF<<0).toString(16)
+    c2 = (Math.random() * 0xFF<<0).toString(16)
+
+    color1 = '#' + c1 + c1 + c1
+    color2 = '#' + c2 + c2 + c2
+
+
+    gradient = ctx.createRadialGradient(x1,y1,32,x2,y2,0)
+    gradient.addColorStop(0, color1)
+    gradient.addColorStop(1, color2)
+    ctx.fillStyle = gradient
+    ctx.fillRect(0,0,32,32)
+    myCanvas.toDataURL()
+
+  {
+    flag: ->
+      if sitePrefix[site]?
+        # we already know how to construct flag url
+        sitePrefix[site] + "/favicon.png?adapted"
+      else if tempFlags[site]?
+        # we already have a temp. flag
+        console.log "wiki.site(#{site}).flag - have temp. flag"
+        tempFlags[site]
+      else
+        # we don't know the url to the real flag, or have a temp flag
+
+        findAdapter(site).prefix (prefix) ->
+          console.log "Prefix for #{site} is #{prefix}"
+          # replace temp flags
+          tempFlag = tempFlags[site]
+          realFlag = sitePrefix[site] + "/favicon.png?replaceTemp"
+          # replace temporary flag where it is used as an image
+          $('img[src="' + tempFlag + '"]').attr('src', realFlag)
+          # replace temporary flag where its used as a background to fork event in journal
+          $('a[target="' + site + '"]').attr('style', 'background-image: url(' + realFlag + ')')
+
+        # create a temp flag, save it for reuse, and return it
+        tempFlag = createTempFlag(site)
+        tempFlags[site] = tempFlag
+        tempFlag
+
+    get: (route, cb) ->
+
+  }

--- a/lib/siteAdapter.coffee
+++ b/lib/siteAdapter.coffee
@@ -1,0 +1,86 @@
+# The siteAdapter handles fetching resources from sites, including origin
+# and local browser storage.
+
+module.exports = siteAdapter = {}
+
+# we save the site prefix once we have determined it...
+sitePrefix = {}
+
+# when asked for a site's flag, if we don't know the current prefix we create
+# a temporary greyscale flag. We save them here, so we can replace them when
+# we know how to get a site's flag
+tempFlags = {}
+
+createTempFlag = (site) ->
+  console.log "creating temp flags for #{site}"
+  myCanvas = document.createElement('canvas')
+  myCanvas.width = 32
+  myCanvas.height = 32
+
+  ctx = myCanvas.getContext('2d')
+
+  x1 = Math.random() * 32
+  y1 = x1
+  y2 = Math.random() * 32
+  x2 = 32 - y2
+
+  c1 = (Math.random() * 0xFF<<0).toString(16)
+  c2 = (Math.random() * 0xFF<<0).toString(16)
+
+  color1 = '#' + c1 + c1 + c1
+  color2 = '#' + c2 + c2 + c2
+
+
+  gradient = ctx.createRadialGradient(x1,y1,32,x2,y2,0)
+  gradient.addColorStop(0, color1)
+  gradient.addColorStop(1, color2)
+  ctx.fillStyle = gradient
+  ctx.fillRect(0,0,32,32)
+  myCanvas.toDataURL()
+
+siteAdapter.local = {
+  flag: -> "/favicon.png?adapted"
+  get: (route, done) ->
+    console.log "wiki.local.get #{route}"
+    if page = localStorage.getItem(route.replace(/\.json$/,''))
+      done null, JSON.parse page
+    else
+      done {msg: "no page named '#{route}' in browser local storage"}
+}
+
+siteAdapter.origin = {
+  flag: -> "/favicon.png?adapted"
+  get: (route, done) ->
+    console.log "wiki.origin.get #{route}"
+    $.ajax
+      type: 'GET'
+      dataType: 'json'
+      url: "/#{route}?adapted"
+      success: (page) -> done null, page
+      error: (xhr, type, msg) -> done {msg, xhr}, null
+}
+
+siteAdapter.site = (site) ->
+  return siteAdapter.origin if !site or site is window.location.host
+
+  flag: ->
+    console.log "wiki.site(#{site}.flag)"
+    if sitePrefix[site]?
+      # we already know how to construct flag url
+      console.log "wiki.site(#{site}).flag - sitePrefix[site]"
+      sitePrefix[site] + "favicon.png?adapted"
+    else if tempFlags[site]?
+      # we already have a temp. flag
+      console.log "wiki.site(#{site}).flag - have temp. flag"
+      tempFlags[site]
+    else
+      # we don't know the url to the real flag, or have a temp flag
+      #findPrefix site, (prefix) ->
+      #  console.log "Prefix for #{site} is #{prefix}"
+
+      # create a temp flag, save it for reuse, and return it
+      tempFlag = createTempFlag(site)
+      tempFlags[site] = tempFlag
+      tempFlag
+
+  get: (route, cb) ->

--- a/lib/siteAdapter.coffee
+++ b/lib/siteAdapter.coffee
@@ -51,7 +51,7 @@ findAdapter = (site) ->
                 sitePrefix[site] = "https://#{site}"
                 done "https://#{site}"
               else
-                #
+                # site is not http or https, so could be using something else, or down...
                 sitePrefix[site] = "//#{site}"
                 done "//#{site}"
           when 'https:'
@@ -61,7 +61,7 @@ findAdapter = (site) ->
                 sitePrefix[site] = "/proxy/#{site}"
                 done "/proxy/#{site}"
               else
-                #
+                # site is not http or https, so could be using something else, or down...
                 sitePrefix[site] = "//#{site}"
                 done "//#{site}"
           else
@@ -149,6 +149,24 @@ siteAdapter.site = (site) ->
         tempFlags[site] = tempFlag
         tempFlag
 
-    get: (route, cb) ->
+    get: (route, done) ->
+      if sitePrefix[site]?
+        url = "#{sitePrefix[site]}/#{route}?adapted"
+        $.ajax
+          type: 'GET'
+          dataType: 'json'
+          url: url
+          success: (data) -> done null, data
+          error: (xhr, type, msg) -> done {msg, xhr}, null
+      else
+        findAdapter(site).prefix (prefix) ->
+          url = "#{prefix}/#{route}?adapted"
+          $.ajax
+            type: 'GET'
+            dataType: 'json'
+            url: url
+            success: (data) -> done null, data
+            error: (xhr, type, msg) -> done {msg, xhr}, null
+
 
   }

--- a/lib/wiki.coffee
+++ b/lib/wiki.coffee
@@ -10,6 +10,13 @@
 
 wiki = {}
 
+# known use: (eventually all server directed xhr and some tags)
+
+siteAdapter = require './siteAdapter'
+wiki.local = siteAdapter.local
+wiki.origin = siteAdapter.origin
+wiki.site = siteAdapter.site
+
 # known use: wiki.asSlug wiki-plugin-reduce/client/reduce.coffee:
 
 wiki.asSlug = require('./page').asSlug

--- a/test/page.coffee
+++ b/test/page.coffee
@@ -1,6 +1,13 @@
 newPage = require('../lib/page').newPage
 expect = require 'expect.js'
 
+wiki = {}
+wiki.site = (site) -> {
+  getURL: (route) ->
+    "//#{site}/#{route}"
+}
+global.wiki = wiki
+
 describe 'page', ->
 
   describe 'newly created', ->


### PR DESCRIPTION
This approach is one that @WardCunningham and myself discussed over on Sunday.

The problems with the previous prototypes start when we request a flag, and don't yet know how to construct the request for it. Determining how to correctly connect to a remote site is asynchronous, which forces get the flag's URL into being asynchronous, which then ripples back through the client.

Here, rather than determine the form of the URL for the flag, if we don't already know how to construct its URL we create a temporary flag, which we will use for the remote site until know to construct the request for the remote site. Once we know the URL for a remote site's flag, we will replace its temporary flag with the real one.

![screen shot 2017-02-14 at 13 24 37](https://cloud.githubusercontent.com/assets/1552489/22931204/a69e45f2-f2bb-11e6-82b9-125c910184f8.png)

The first commit here will just use a temporary grayscale gradient flag for a remote site. It does not yet have the logic for determining the correct route to a remote site, replacing the temporary flags, or fetching remote resources.