### PR TITLE
toggle wiki editing

### DIFF
--- a/lib/editor.coffee
+++ b/lib/editor.coffee
@@ -27,6 +27,7 @@ escape = (string) ->
 
 textEditor = ($item, item, option={}) ->
   console.log 'textEditor', item.id, option
+  return unless $('.editEnable').is(':visible')
 
   keydownHandler = (e) ->
 

--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -219,7 +219,7 @@ $ ->
     .click ->
       $('.editEnable').toggle()
       $('.page').each refresh.cycle
-  $('.editEnable').toggle()
+  $('.editEnable').toggle() unless isAuthenticated
 
   target.bind()
 

--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -212,6 +212,15 @@ $ ->
     .click ->
       dialog.open "Lineup Activity", lineupActivity.show()
 
+  # $('.editEnable').is(':visible')
+  $("<span> wiki <span class=editEnable>✔︎</span> &nbsp; </span>")
+    .css({"cursor":"pointer"})
+    .appendTo('footer')
+    .click ->
+      $('.editEnable').toggle()
+      $('.page').each refresh.cycle
+  $('.editEnable').toggle()
+
   target.bind()
 
 

--- a/lib/refresh.coffee
+++ b/lib/refresh.coffee
@@ -238,7 +238,7 @@ renderPageIntoPageElement = (pageObject, $page) ->
   $paper = $("<div class='paper' />")
   $page.append($paper)
   [$twins, $header, $story, $journal, $footer] = ['twins', 'header', 'story', 'journal', 'footer'].map (className) ->
-    $("<div />").addClass(className).appendTo($paper)
+    $("<div />").addClass(className).appendTo($paper) if className != 'journal' or $('.editEnable').is(':visible')
 
   emitHeader $header, $page, pageObject
   emitTimestamp $header, $page, pageObject
@@ -248,13 +248,14 @@ renderPageIntoPageElement = (pageObject, $page) ->
     $story.append $item
     plugin.do $item, item, done
 
-  pageObject.seqActions (each, done) ->
-    addToJournal $journal, each.separator if each.separator
-    addToJournal $journal, each.action
-    done()
+  if $('.editEnable').is(':visible')
+    pageObject.seqActions (each, done) ->
+      addToJournal $journal, each.separator if each.separator
+      addToJournal $journal, each.action
+      done()
 
   emitTwins $page
-  emitControls $journal
+  emitControls $journal if $('.editEnable').is(':visible')
   emitFooter $footer, pageObject
 
 
@@ -275,9 +276,10 @@ rebuildPage = (pageObject, $page) ->
   #STATE -- update url when adding new page, removing others
   state.setUrl()
 
-  initDragging $page
-  initMerging $page
-  initAddButton $page
+  if $('.editEnable').is(':visible')
+    initDragging $page 
+    initMerging $page
+    initAddButton $page
   $page
 
 buildPage = (pageObject, $page) ->

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "wiki-client",
-  "version": "0.9.0-1",
+  "version": "0.9.0-2",
   "publishConfig": {
-    "tag": "next"
+    "tag": "optional"
   },
   "description": "Federated Wiki - Client-side Javascript",
   "keywords": [


### PR DESCRIPTION
This pull request is a variation of wiki@next that makes wiki editing optional.

Here with `wiki` not selected. Drag just selects text. No journal or action buttons.
![image](https://cloud.githubusercontent.com/assets/12127/24590157/42155880-179d-11e7-8fe6-a3ac5e986a34.png)
Click `wiki` in the footer to restore normal wiki edit operations.
![image](https://cloud.githubusercontent.com/assets/12127/24590213/463b2c68-179e-11e7-935d-218c66eef330.png)

