### PR TITLE
site unreachable?

### DIFF
--- a/lib/siteAdapter.coffee
+++ b/lib/siteAdapter.coffee
@@ -208,7 +208,7 @@ siteAdapter.site = (site) ->
       if sitePrefix[site]?
         if sitePrefix[site] is ""
           console.log "#{site} is unreachable"
-          done {"#{site} is unreachable"}, null
+          done {msg: "#{site} is unreachable", xhr: {status: 0}}, null
         else
           url = "#{sitePrefix[site]}/#{route}"
           $.ajax
@@ -221,7 +221,7 @@ siteAdapter.site = (site) ->
         findAdapter(site).prefix (prefix) ->
           if prefix is ""
             console.log "#{site} is unreachable"
-            done {"#{site} is unreachable"}, null
+            done {msg: "#{site} is unreachable", xhr: {status: 0}}, null
           else
             url = "#{prefix}/#{route}"
             $.ajax

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "wiki-client",
   "version": "0.9.0-2",
   "publishConfig": {
-    "tag": "optional"
+    "tag": "next"
   },
   "description": "Federated Wiki - Client-side Javascript",
   "keywords": [


### PR DESCRIPTION
When we find that a site is unreachable (down?) in findAdapter we set the prefix to `""`. However when we try and get an item from that page we didn't use the callback correctly.

Here we set `status` so the code calling making the call can handle the site not being present correctly.

This fixes #189