### PR TITLE
rebuild existing pages on toggle wiki

### DIFF
--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -218,7 +218,10 @@ $ ->
     .appendTo('footer')
     .click ->
       $('.editEnable').toggle()
-      $('.page').each refresh.cycle
+      $('.page').each ->
+        $page = $(this)
+        pageObject = lineup.atKey $page.data('key')
+        refresh.rebuildPage pageObject, $page.empty()
   $('.editEnable').toggle() unless isAuthenticated
 
   target.bind()


### PR DESCRIPTION
In an earlier comment I noted that toggling read-write would cause an unwanted accumulation in the lineup model. https://github.com/fedwiki/wiki-client/pull/187#issuecomment-291378581

I've tracked this problem down to a call into lib/refresh at too high a level. The lineup is intact so we should instead just rebuild the dom $page from available information. There is an entry point for exactly this purpose and a sample call a little higher in the code where the page `create` button rebuilds an existing (ghost) page.
```
.delegate 'button.create', 'click', (e) -> ...
```
