### PR TITLE
detect and process page delete

### DIFF
--- a/client/style/style.css
+++ b/client/style/style.css
@@ -290,7 +290,7 @@ p.readout {
 }
 
 .page.recycler > .paper {
-  box-shadow: inset 0px 0px 40px 0px rgba(107,142,35,.5)
+  box-shadow: inset 0px 0px 40px 0px rgba(220,0,0,.5)
 }
 
 .paper {

--- a/client/style/style.css
+++ b/client/style/style.css
@@ -289,6 +289,10 @@ p.readout {
   box-shadow: inset 0px 0px 40px 0px rgba(0,180,220,.5);
 }
 
+.page.recycler > .paper {
+  box-shadow: inset 0px 0px 40px 0px rgba(107,142,35,.5)
+}
+
 .paper {
   /*width: 430px;*/
   padding: 30px;

--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -139,16 +139,29 @@ $ ->
       $page = $(e.target).parents('.page')
       return if $page.find('.future').length
       pageObject = lineup.atKey $page.data('key')
-      action = {type: 'fork'}
-      if $page.hasClass('local')
-        return if pageHandler.useLocalStorage()
-        $page.removeClass('local')
-      else if pageObject.isRemote()
-        action.site = pageObject.getRemoteSite()
-      if $page.data('rev')?
-        $page.find('.revision').remove()
-      $page.removeClass 'ghost'
-      pageHandler.put $page, action
+      if pageObject.getRevision()
+        action = {type: 'fork'}
+        if $page.hasClass('local')
+          return if pageHandler.useLocalStorage()
+          $page.removeClass('local')
+        else if pageObject.isRemote()
+          action.site = pageObject.getRemoteSite()
+        if $page.data('rev')?
+          $page.find('.revision').remove()
+        $page.removeClass 'ghost'
+        pageHandler.put $page, action
+      else
+        console.log 'fork to delete'
+        pageHandler.delete pageObject, $page, (err) ->
+          return if err?
+          console.log 'server delete successful'
+          futurePage = refresh.newFuturePage(pageObject.getTitle(), pageObject.getCreate())
+          pageObject.become futurePage
+          # [slug, rev] = $page.attr('id').split('_rev')
+          # $page.attr('id',slug)
+          $page.attr 'id', futurePage.getSlug()
+          refresh.rebuildPage pageObject, $page
+          $page.addClass('ghost')
 
     .delegate 'button.create', 'click', (e) ->
       getTemplate $(e.target).data('slug'), (template) ->

--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -155,13 +155,17 @@ $ ->
         pageHandler.delete pageObject, $page, (err) ->
           return if err?
           console.log 'server delete successful'
-          futurePage = refresh.newFuturePage(pageObject.getTitle(), pageObject.getCreate())
-          pageObject.become futurePage
-          # [slug, rev] = $page.attr('id').split('_rev')
-          # $page.attr('id',slug)
-          $page.attr 'id', futurePage.getSlug()
-          refresh.rebuildPage pageObject, $page
-          $page.addClass('ghost')
+          if pageObject.isRecycler()
+            # make recycler page into a ghost
+            $page.addClass('ghost')
+          else
+            futurePage = refresh.newFuturePage(pageObject.getTitle(), pageObject.getCreate())
+            pageObject.become futurePage
+            # [slug, rev] = $page.attr('id').split('_rev')
+            # $page.attr('id',slug)
+            $page.attr 'id', futurePage.getSlug()
+            refresh.rebuildPage pageObject, $page
+            $page.addClass('ghost')
 
     .delegate 'button.create', 'click', (e) ->
       getTemplate $(e.target).data('slug'), (template) ->

--- a/lib/neighborhood.coffee
+++ b/lib/neighborhood.coffee
@@ -64,6 +64,17 @@ neighborhood.updateSitemap = (pageObject)->
     sitemap.push entry
   $('body').trigger 'new-neighbor-done', site
 
+neighborhood.deleteFromSitemap = (pageObject)->
+  site = location.host
+  return unless neighborInfo = neighborhood.sites[site]
+  return if neighborInfo.sitemapRequestInflight
+  slug = pageObject.getSlug()
+  sitemap = neighborInfo.sitemap
+  index = sitemap.findIndex (slot) -> slot.slug == slug
+  return unless index >= 0
+  sitemap.splice(index)
+  $('body').trigger 'delete-neighbor-done', site
+
 neighborhood.listNeighbors = ()->
   _.keys( neighborhood.sites )
 

--- a/lib/page.coffee
+++ b/lib/page.coffee
@@ -50,10 +50,13 @@ newPage = (json, site) ->
     page.plugin?
 
   isRemote = ->
-    ! (site in [undefined, null, 'view', 'origin', 'local'])
+    ! (site in [undefined, null, 'view', 'origin', 'local', 'recycler'])
 
   isLocal = ->
     site == 'local'
+
+  isRecycler = ->
+    site == 'recycler'
 
   getRemoteSite = (host = null) ->
     if isRemote() then site else host
@@ -184,6 +187,6 @@ newPage = (json, site) ->
     isCreate = (action) -> action.type == 'create'
     page.journal.reverse().find(isCreate)
 
-  {getRawPage, getContext, isPlugin, isRemote, isLocal, getRemoteSite, getRemoteSiteDetails, getSlug, getNeighbors, getTitle, setTitle, getRevision, getDate, getTimestamp, getSynopsis, addItem, getItem, addParagraph, seqItems, seqActions, become, siteLineup, merge, apply, getCreate}
+  {getRawPage, getContext, isPlugin, isRemote, isLocal, isRecycler, getRemoteSite, getRemoteSiteDetails, getSlug, getNeighbors, getTitle, setTitle, getRevision, getDate, getTimestamp, getSynopsis, addItem, getItem, addParagraph, seqItems, seqActions, become, siteLineup, merge, apply, getCreate}
 
 module.exports = {newPage, asSlug, asTitle, pageEmitter}

--- a/lib/pageHandler.coffee
+++ b/lib/pageHandler.coffee
@@ -198,9 +198,16 @@ pageHandler.put = ($page, action) ->
 
 pageHandler.delete = (pageObject, $page, done) ->
   console.log 'delete server-side'
-  wiki.origin.delete "#{pageObject.getSlug()}.json", (err) ->
-    more = ->
-      # err = null
-      neighborhood.deleteFromSitemap pageObject unless err?
-      done err
-    setTimeout(more, 300) # simulate server turnaround
+  console.log 'pageObject:', pageObject
+  if pageObject.isRecycler()
+    wiki.recycler.delete "#{pageObject.getSlug()}.json", (err) ->
+      more = ->
+        done err
+      setTimeout(more, 300)
+  else
+    wiki.origin.delete "#{pageObject.getSlug()}.json", (err) ->
+      more = ->
+        # err = null
+        neighborhood.deleteFromSitemap pageObject unless err?
+        done err
+      setTimeout(more, 300) # simulate server turnaround

--- a/lib/pageHandler.coffee
+++ b/lib/pageHandler.coffee
@@ -51,6 +51,7 @@ recursiveGet = ({pageInformation, whenGotten, whenNotGotten, localContext}) ->
   adapter = switch site
     when 'local' then wiki.local
     when 'origin' then wiki.origin
+    when 'recycler' then wiki.recycler
     when 'view' then localBeforeOrigin
     else wiki.site(site)
 

--- a/lib/pageHandler.coffee
+++ b/lib/pageHandler.coffee
@@ -195,3 +195,12 @@ pageHandler.put = ($page, action) ->
     pushToLocal($page, pagePutInfo, action)
   else
     pushToServer($page, pagePutInfo, action)
+
+pageHandler.delete = (pageObject, $page, done) ->
+  console.log 'delete server-side'
+  wiki.origin.delete "#{pageObject.getSlug()}.json", (err) ->
+    more = ->
+      # err = null
+      neighborhood.deleteFromSitemap pageObject unless err?
+      done err
+    setTimeout(more, 300) # simulate server turnaround

--- a/lib/refresh.coffee
+++ b/lib/refresh.coffee
@@ -145,7 +145,10 @@ handleHeaderClick = (e) ->
 
 
 emitHeader = ($header, $page, pageObject) ->
-  remote = pageObject.getRemoteSite location.host
+  if pageObject.isRecycler()
+    remote = 'recycler'
+  else
+    remote = pageObject.getRemoteSite location.host
   tooltip = pageObject.getRemoteSiteDetails location.host
   $header.append """
     <h1 title="#{tooltip}">
@@ -267,6 +270,7 @@ createMissingFlag = ($page, pageObject) ->
 
 rebuildPage = (pageObject, $page) ->
   $page.addClass('local') if pageObject.isLocal()
+  $page.addClass('recycler') if pageObject.isRecycler()
   $page.addClass('remote') if pageObject.isRemote()
   $page.addClass('plugin') if pageObject.isPlugin()
 
@@ -277,7 +281,7 @@ rebuildPage = (pageObject, $page) ->
   state.setUrl()
 
   if $('.editEnable').is(':visible')
-    initDragging $page 
+    initDragging $page
     initMerging $page
     initAddButton $page
   $page

--- a/lib/refresh.coffee
+++ b/lib/refresh.coffee
@@ -290,6 +290,40 @@ buildPage = (pageObject, $page) ->
   $page.data('key', lineup.addPage(pageObject))
   rebuildPage(pageObject, $page)
 
+newFuturePage = (title, create) ->
+  slug = asSlug title
+  pageObject = newPage()
+  pageObject.setTitle(title)
+  hits = []
+  for site, info of neighborhood.sites
+    if info.sitemap?
+      result = _.find info.sitemap, (each) ->
+        each.slug == slug
+      if result?
+        hits.push
+          "type": "reference"
+          "site": site
+          "slug": slug
+          "title": result.title || slug
+          "text": result.synopsis || ''
+  if hits.length > 0
+    pageObject.addItem
+      'type': 'future'
+      'text': 'We could not find this page in the expected context.'
+      'title': title
+      'create': create
+    pageObject.addItem
+      'type': 'paragraph'
+      'text': "We did find the page in your current neighborhood."
+    pageObject.addItem hit for hit in hits
+  else
+     pageObject.addItem
+      'type': 'future'
+      'text': 'We could not find this page.'
+      'title': title
+      'create': create
+  pageObject
+
 cycle = ->
   $page = $(this)
 
@@ -300,44 +334,13 @@ cycle = ->
     site: $page.data('site')
   }
 
-  createGhostPage = ->
+  whenNotGotten = ->
     title = $("""a[href="/#{slug}.html"]:last""").text() or slug
     key = $("""a[href="/#{slug}.html"]:last""").parents('.page').data('key')
     create = lineup.atKey(key)?.getCreate()
-    #NEWPAGE future after failed pageHandler.get then buildPage
-    pageObject = newPage()
-    pageObject.setTitle(title)
-
-    hits = []
-    for site, info of neighborhood.sites
-      if info.sitemap?
-        result = _.find info.sitemap, (each) ->
-          each.slug == slug
-        if result?
-          hits.push
-            "type": "reference"
-            "site": site
-            "slug": slug
-            "title": result.title || slug
-            "text": result.synopsis || ''
-    if hits.length > 0
-      pageObject.addItem
-        'type': 'future'
-        'text': 'We could not find this page in the expected context.'
-        'title': title
-        'create': create
-      pageObject.addItem
-        'type': 'paragraph'
-        'text': "We did find the page in your current neighborhood."
-      pageObject.addItem hit for hit in hits
-    else
-       pageObject.addItem
-        'type': 'future'
-        'text': 'We could not find this page.'
-        'title': title
-        'create': create
-
+    pageObject = newFuturePage(title)
     buildPage( pageObject, $page ).addClass('ghost')
+
 
   whenGotten = (pageObject) ->
     buildPage( pageObject, $page )
@@ -346,7 +349,7 @@ cycle = ->
 
   pageHandler.get
     whenGotten: whenGotten
-    whenNotGotten: createGhostPage
+    whenNotGotten: whenNotGotten
     pageInformation: pageInformation
 
-module.exports = {cycle, emitTwins, buildPage, rebuildPage}
+module.exports = {cycle, emitTwins, buildPage, rebuildPage, newFuturePage}

--- a/lib/siteAdapter.coffee
+++ b/lib/siteAdapter.coffee
@@ -125,6 +125,7 @@ siteAdapter.recycler = {
 
 siteAdapter.site = (site) ->
   return siteAdapter.origin if !site or site is window.location.host
+  return siteAdapter.recycler if site is 'recycler'
 
   createTempFlag = (site) ->
     console.log "creating temp flags for #{site}"

--- a/lib/siteAdapter.coffee
+++ b/lib/siteAdapter.coffee
@@ -108,6 +108,13 @@ siteAdapter.origin = {
         'action': JSON.stringify(data)
       success: () -> done null
       error: (xhr, type, msg) -> done {xhr, type, msg}
+  delete: (route, done) ->
+    console.log "wiki.origin.delete #{route}"
+    $.ajax
+      type: 'DELETE'
+      url: "/#{route}"
+      success: () -> done null
+      error: (xhr, type, msg) -> done {xhr, type, msg}
 }
 
 siteAdapter.recycler = {

--- a/lib/siteAdapter.coffee
+++ b/lib/siteAdapter.coffee
@@ -128,6 +128,13 @@ siteAdapter.recycler = {
       url: "/recycler/#{route}"
       success: (page) -> done null, page
       error: (xhr, type, msg) -> done {msg, xhr}, null
+  delete: (route, done) ->
+    console.log "wiki.recycler.delete #{route}"
+    $.ajax
+      type: 'DELETE'
+      url: "/recycler/#{route}"
+      success: () -> done null
+      error: (xhr, type, msg) -> done {xhr, type, msg}
 }
 
 siteAdapter.site = (site) ->

--- a/lib/siteAdapter.coffee
+++ b/lib/siteAdapter.coffee
@@ -108,7 +108,19 @@ siteAdapter.origin = {
         'action': JSON.stringify(data)
       success: () -> done null
       error: (xhr, type, msg) -> done {xhr, type, msg}
+}
 
+siteAdapter.recycler = {
+  flag: -> "/recycler/favicon.png"
+  getURL: (route) -> "/recycler/#{route}"
+  get: (route, done) ->
+    console.log "wiki.recycler.get #{route}"
+    $.ajax
+      type: 'GET'
+      dataType: 'json'
+      url: "/recycler/#{route}"
+      success: (page) -> done null, page
+      error: (xhr, type, msg) -> done {msg, xhr}, null
 }
 
 siteAdapter.site = (site) ->

--- a/lib/wiki.coffee
+++ b/lib/wiki.coffee
@@ -15,6 +15,7 @@ wiki = {}
 siteAdapter = require './siteAdapter'
 wiki.local = siteAdapter.local
 wiki.origin = siteAdapter.origin
+wiki.recycler = siteAdapter.recycler
 wiki.site = siteAdapter.site
 
 # known use: wiki.asSlug wiki-plugin-reduce/client/reduce.coffee:


### PR DESCRIPTION
Work in progress. See checklist below.

After six years, finally working on delete command. To delete a page, recall its creation with no content, then fork that to the server. New logic interprets forking a page with no contents as delete. (This is like saving a Paragraph with no text to delete it.)

![kwecxeerxsqunafybrvqhsjr](https://user-images.githubusercontent.com/12127/27843522-72f71342-60c9-11e7-9f3b-949d7b19360b.png)

After a successful server-side DELETE, the page appears as it did before it was created. The create action in the future journal is new but preserves some parameters from the old such as the Transporter continuation logic, if any.

![pgrgbhkmbbpvsgmzweaqcpeb](https://user-images.githubusercontent.com/12127/27843534-99cfd67a-60c9-11e7-9290-7db1abd6bba2.png)

So far we have discovered and addressed many client-side issues while simulating server side delete in pageHandler.delete with a timer and fixed value for err status. We either delete the file with a shell command or just reload to discover that the deleted page has reappeared.
```
(cd ~/.wiki; rm pages/testing-fork-to-delete; rm status/sitemap*)
```

More to do client-side:
- [ ] handle delete-neighbor-done events to adjust twins and recent changes
- [ ] handle cases where page is in browser local storage
- [ ] handle non-origin and not-logged-in cases
- [ ] test with downstream dependents within lineup
- [ ] turn other lineup copies to ghosts, check that they can be forked to undelete
- [ ] consider longer-term undelete scenarios from server-side recycling
- [ ] test with Transporter that uses create continuations
- [ ] improve Future plugin's wording for the just-deleted case
- [ ] delete recycled page

We will expect a coordinated update to wiki-server.