### PR TITLE
prevent default for alt-s

### DIFF
--- a/lib/editor.coffee
+++ b/lib/editor.coffee
@@ -32,6 +32,7 @@ textEditor = ($item, item, option={}) ->
   keydownHandler = (e) ->
 
     if (e.altKey || e.ctlKey || e.metaKey) and e.which == 83 #alt-s
+      e.preventDefault()
       $textarea.focusout()
       return false
 


### PR DESCRIPTION
We prevent the default alt-s handling when saving edits. This commit mimics the adjacent alt-i handling. This seems harmless and safe to merge even though it has not yet been tested on the device where the unwanted event propagation issue was reported, #183.

@cliveb