### PR TITLE
More concise synopsis.

### DIFF
--- a/lib/synopsis.coffee
+++ b/lib/synopsis.coffee
@@ -14,4 +14,6 @@ module.exports = (page) ->
     synopsis ||= page.story? && "A page with #{page.story.length} items."
   else
     synopsis = 'A page with no story.'
-  return synopsis
+  # discard anything after the first line break, after trimming any at beginning
+  synopsis = synopsis.trim().split(/\r|\n/, 1)[0]
+  return synopsis.substring(0, 560)


### PR DESCRIPTION
We take the first paragraph of the candidate synopsis, and then reduce it to the first 560 characters.

This is a proposed fix for fedwiki/wiki-server#136