### PR TITLE
be specific looking for internal link text

### DIFF
--- a/lib/refresh.coffee
+++ b/lib/refresh.coffee
@@ -335,8 +335,9 @@ cycle = ->
   }
 
   whenNotGotten = ->
-    title = $("""a[href="/#{slug}.html"]:last""").text() or slug
-    key = $("""a[href="/#{slug}.html"]:last""").parents('.page').data('key')
+    link = $("""a.internal[href="/#{slug}.html"]:last""")
+    title = link.text() or slug
+    key = link.parents('.page').data('key')
     create = lineup.atKey(key)?.getCreate()
     pageObject = newFuturePage(title)
     buildPage( pageObject, $page ).addClass('ghost')


### PR DESCRIPTION
Fix for issue #202 

When pageHandler can't find a page the refresh logic builds a Future as substitute. This logic looks for the internal link from which to recover the proper title. This commit revises the jquery selector used to be specific that it wants links of class .internal  so that any intervening pages with the same link in its flag does not confuse the logic.

![image](https://user-images.githubusercontent.com/12127/31303689-c37ff7ce-aac6-11e7-86e9-c8c6c75796f2.png)

Thanks go to @opn for recognizing the repeatable case.