### PR TITLE
simple alt-m handler, might be best

### DIFF
--- a/lib/editor.coffee
+++ b/lib/editor.coffee
@@ -32,15 +32,21 @@ textEditor = ($item, item, option={}) ->
 
   keydownHandler = (e) ->
 
-    if (e.altKey || e.ctlKey || e.metaKey) and e.which == 83 #alt-s
+    if (e.altKey || e.ctlKey || e.metaKey) and e.which == 83 #alt-s for save
       e.preventDefault()
       $textarea.focusout()
       return false
 
-    if (e.altKey || e.ctlKey || e.metaKey) and e.which == 73 #alt-i
+    if (e.altKey || e.ctlKey || e.metaKey) and e.which == 73 #alt-i for information
       e.preventDefault()
       page = $(e.target).parents('.page') unless e.shiftKey
       link.doInternalLink "about #{item.type} plugin", page
+      return false
+
+    if (e.altKey || e.ctlKey || e.metaKey) and e.which == 77 #alt-m for menu
+      e.preventDefault()
+      $item.removeClass(item.type).addClass(item.type = 'factory')
+      $textarea.focusout()
       return false
 
     # provides automatic new paragraphs on enter and concatenation on backspace


### PR DESCRIPTION
Type cmd/alt-m to return to plugin menu.

- recognized during edit only
- menu does not erase text, returns to text editor on most selections
- further text change required to persist choice

Typical workflow:
- recognize preferred plugin while editing
- cmd/alt-m to select desired plugin
- continue editing then cmd/alt-s to save

Preferred mechanism for adding captions to images:
- split into the editor
- write the desired caption
- cmd/alt-m to return to menu
- drop image on the menu

![image](https://user-images.githubusercontent.com/12127/32703935-44ea3394-c7b2-11e7-834e-5c16829718ee.png)
![image](https://user-images.githubusercontent.com/12127/32703944-6f0cde88-c7b2-11e7-83bf-61cd1a0c1274.png)
![image](https://user-images.githubusercontent.com/12127/32703959-b1be8344-c7b2-11e7-8aa1-24696a247d43.png)
