### PR TITLE
Change the site adapter discovery mechanism

### DIFF
--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -118,9 +118,15 @@ $ ->
       finishClick e, name
 
     .delegate 'img.remote', 'click', (e) ->
-      name = $(e.target).data('slug')
-      pageHandler.context = [$(e.target).data('site')]
-      finishClick e, name
+      # expand to handle click on temporary flag
+      if $(e.target).attr('src').startsWith('data:image/png')
+        e.preventDefault()
+        site = $(e.target).data('site')
+        wiki.site(site).refresh()
+      else
+        name = $(e.target).data('slug')
+        pageHandler.context = [$(e.target).data('site')]
+        finishClick e, name
 
     .delegate '.revision', 'dblclick', (e) ->
       e.preventDefault()

--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -122,7 +122,8 @@ $ ->
       if $(e.target).attr('src').startsWith('data:image/png')
         e.preventDefault()
         site = $(e.target).data('site')
-        wiki.site(site).refresh()
+        wiki.site(site).refresh () ->
+          # empty function...
       else
         name = $(e.target).data('slug')
         pageHandler.context = [$(e.target).data('site')]

--- a/lib/neighborhood.coffee
+++ b/lib/neighborhood.coffee
@@ -30,6 +30,8 @@ populateSiteInfoFor = (site,neighborInfo)->
         $('body').trigger 'new-neighbor-done', site
       else
         transition site, 'fetch', 'fail'
+        wiki.site(site).refresh () ->
+          # empty function
 
   now = Date.now()
   if now > nextAvailableFetch
@@ -39,6 +41,11 @@ populateSiteInfoFor = (site,neighborInfo)->
     setTimeout fetchMap, nextAvailableFetch - now
     nextAvailableFetch += nextFetchInterval
 
+neighborhood.retryNeighbor = (site)->
+  console.log 'retrying neighbor'
+  neighborInfo = {}
+  neighborhood.sites[site] = neighborInfo
+  populateSiteInfoFor(site, neighborInfo)
 
 neighborhood.registerNeighbor = (site)->
   return if neighborhood.sites[site]?

--- a/lib/neighbors.coffee
+++ b/lib/neighbors.coffee
@@ -35,6 +35,11 @@ bind = ->
       totalPages += pageCount
       $('.searchbox .pages').text "#{totalPages} pages"
     .delegate '.neighbor img', 'click', (e) ->
-      link.doInternalLink 'welcome-visitors', null, @.title.split("\n")[0]
+      # add handling refreshing neighbor that has failed
+      if $(e.target).parent().hasClass('fail')
+        site = $(e.target).attr('title')
+        wiki.site(site).refresh()
+      else
+        link.doInternalLink 'welcome-visitors', null, @.title.split("\n")[0]
 
 module.exports = {inject, bind}

--- a/lib/neighbors.coffee
+++ b/lib/neighbors.coffee
@@ -4,6 +4,8 @@
 # cause them to animate as an indication of work in progress.
 
 link = require './link'
+wiki = require './wiki'
+neighborhood = require './neighborhood'
 
 sites = null
 totalPages = 0
@@ -37,8 +39,11 @@ bind = ->
     .delegate '.neighbor img', 'click', (e) ->
       # add handling refreshing neighbor that has failed
       if $(e.target).parent().hasClass('fail')
+        $(e.target).parent().removeClass('fail').addClass('wait')
         site = $(e.target).attr('title')
-        wiki.site(site).refresh()
+        wiki.site(site).refresh () ->
+          console.log 'about to retry neighbor'
+          neighborhood.retryNeighbor(site)
       else
         link.doInternalLink 'welcome-visitors', null, @.title.split("\n")[0]
 

--- a/lib/siteAdapter.coffee
+++ b/lib/siteAdapter.coffee
@@ -291,10 +291,10 @@ siteAdapter.site = (site) ->
               success: (data) -> done null, data
               error: (xhr, type, msg) -> done {msg, xhr}, null
 
-    refresh: () ->
+    refresh: (done) ->
       # Refresh is used to redetermine the sitePrefix prefix, and update the
       # stored value.
-      
+
       console.log "Refreshing #{site}"
 
       if !tempFlags[site]?
@@ -316,9 +316,9 @@ siteAdapter.site = (site) ->
         findAdapterQ.push {site: site}, (prefix) ->
           localForage.setItem(site, prefix).then (value) ->
             if prefix is ""
-              console.log "Prefix for #{site} is undetermined..."
+              console.log "Refreshed prefix for #{site} is undetermined..."
             else
-              console.log "Prefix for #{site} is #{prefix}"
+              console.log "Refreshed prefix for #{site} is #{prefix}"
               # replace temp flags
               tempFlag = tempFlags[site]
               realFlag = sitePrefix[site] + "/favicon.png"
@@ -326,12 +326,15 @@ siteAdapter.site = (site) ->
               $('img[src="' + tempFlag + '"]').attr('src', realFlag)
               # replace temporary flag where its used as a background to fork event in journal
               $('a[target="' + site + '"]').attr('style', 'background-image: url(' + realFlag + ')')
+            done()
           .catch (err) ->
             console.log "findAdapter setItem error: ", site, err
             sitePrefix[site] = ""
+            done()
 
       .catch (err) ->
         console.log 'refresh error ', site, err
+        done()
         # same as if delete worked?
 
 

--- a/lib/siteAdapter.coffee
+++ b/lib/siteAdapter.coffee
@@ -224,6 +224,7 @@ siteAdapter.site = (site) ->
             $('img[src="' + tempFlag + '"]').attr('src', realFlag)
             # replace temporary flag where its used as a background to fork event in journal
             $('a[target="' + site + '"]').attr('style', 'background-image: url(' + realFlag + ')')
+            tempFlags[site] = null
 
 
         # create a temp flag, save it for reuse, and return it
@@ -293,11 +294,22 @@ siteAdapter.site = (site) ->
     refresh: () ->
       # Refresh is used to redetermine the sitePrefix prefix, and update the
       # stored value.
-      if !tempFlags[site]?
-        console.log "Site #{site} does not have temp flag - not refreshing"
-        return
-
+      
       console.log "Refreshing #{site}"
+
+      if !tempFlags[site]?
+        # refreshing route for a site that we know the route for...
+        # currently performed when clicking on a neighbor that we
+        # can't retrieve a sitemap for.
+
+        # replace flag with temp flags
+        tempFlag = createTempFlag(site)
+        tempFlags[site] = tempFlag
+        realFlag = sitePrefix[site] + "/favicon.png"
+        # replace flag with temporary flag where it is used as an image
+        $('img[src="' + realFlag + '"]').attr('src', tempFlag)
+        # replace temporary flag where its used as a background to fork event in journal
+        $('a[target="' + site + '"]').attr('style', 'background-image: url(' + tempFlag + ')')
 
       sitePrefix[site] = null
       localForage.removeItem(site).then () ->

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "test": "grunt mochaTest"
   },
   "devDependencies": {
+    "async": "^2.6.0",
     "coffee-script": "^1.12.4",
     "coffeeify": "^2.1.0",
     "expect.js": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     }
   ],
   "dependencies": {
+    "localforage": "^1.5.5",
     "underscore": "^1.8.3"
   },
   "scripts": {


### PR DESCRIPTION
Here we switch to using a queue to prevent overloading the browser, or a remote server, and using ajax to GET the image which allows us to detect any redirects that will cause problems later in the flow.