### PR TITLE
wide margins for print

### DIFF
--- a/client/style/print.css
+++ b/client/style/print.css
@@ -9,7 +9,7 @@ body {
 .main {
 	width: auto;
 	border: 0;
-	margin: 0 5%;
+	margin: 10% 20%;
 	padding: 0;
 	float: none !important;
 }
@@ -19,7 +19,7 @@ body {
 }
 
 .story {
-	text-align: justify;
+	text-align: left;
 }
 
 p {

--- a/client/style/print.css
+++ b/client/style/print.css
@@ -34,16 +34,17 @@ img.remote {
 }
 
 A:link, A:visited {
-	background: white;
-	color: black;
-	text-decoration: underline;
-	font-weight: 110%;
+	background: transparent;
+	color: #111;
+	text-decoration: none;
+	font-weight: 600;
 }
 
 .story a:link:after,
 .story a:visited:after {
 	content: " (" attr(href) ") ";
 	font-size: 90%;
+	font-weight: 500;
 }
 
 .journal {
@@ -51,8 +52,8 @@ A:link, A:visited {
 }
 
 .footer {
+	font-size: 10pt;
 	padding-top: 24pt;
-	text-align: center;
 	float: bottom;
 	string-set: Footer self;
 }


### PR DESCRIPTION
Sometimes our short paragraphs and narrow column spill ungracefully onto the printed page. Better to add broad margins and retain some approximation of the online look.

![image](https://user-images.githubusercontent.com/12127/33807119-bdd08152-dd86-11e7-923b-24878d42099c.png)

Becomes:

![image](https://user-images.githubusercontent.com/12127/33807146-1ec4cd9c-dd87-11e7-8ee2-d8cbda9af091.png)

From the original:

![image](https://user-images.githubusercontent.com/12127/33807166-45d718f4-dd87-11e7-81f8-1d6c850cd232.png)
