### PR TITLE
lame attempt to broaden plugin access to new page logic

### DIFF
--- a/lib/link.coffee
+++ b/lib/link.coffee
@@ -24,8 +24,8 @@ createPage = (name, loc) ->
   $page.data('site', site) if site
   $page
 
-showPage = (name, loc) ->
-  createPage(name, loc).appendTo('.main').each refresh.cycle
+showPage = (name, loc, main='.main') ->
+  createPage(name, loc).appendTo(main).each refresh.cycle
 
 doInternalLink = (name, $page, site=null) ->
   name = asSlug(name)

--- a/lib/wiki.coffee
+++ b/lib/wiki.coffee
@@ -52,6 +52,7 @@ link = require('./link')
 wiki.createPage = link.createPage ##
 wiki.doInternalLink = link.doInternalLink
 wiki.showResult = link.showResult
+wiki.showPage = link.showPage
 
 # known use: wiki.getScript  wiki-plugin-bars/client/bars.coffee:
 # known use: wiki.getScript  wiki-plugin-code/client/code.coffee:


### PR DESCRIPTION
Not to be merged without serious consideration.

This is some work in progress on a plugin that now slips my mind required access to link.showPage but found that logic deeper in the refresh cycle had unfortunate assumptions (unnecessary dependencies) that stalled this work.

(It is coming back to me now. It was print logic in the never finished table of contents plugin.)

We are well overdue for a rethink of how plugins might cooperate with core-javascript. Ideas?
