### PR TITLE
avoid trailing space in flag anchor

### DIFF
--- a/lib/refresh.coffee
+++ b/lib/refresh.coffee
@@ -153,8 +153,8 @@ emitHeader = ($header, $page, pageObject) ->
   $header.append """
     <h1 title="#{tooltip}">
       <a href="#{pageObject.siteLineup()}" target="#{remote}">
-        <img src="#{wiki.site(remote).flag()}" height="32px" class="favicon">
-      </a> #{resolve.escape pageObject.getTitle()}
+        <img src="#{wiki.site(remote).flag()}" height="32px" class="favicon"></a>
+      #{resolve.escape pageObject.getTitle()}
     </h1>
   """
   $header.find('a').on 'click', handleHeaderClick


### PR DESCRIPTION
This makes a difference in the appearance of tab-sequence highlights.

Without this change:
![image](https://user-images.githubusercontent.com/12127/33809921-04ef9d58-ddb3-11e7-8707-17c25678e96b.png)


With this change:
![image](https://user-images.githubusercontent.com/12127/33809924-1a1db4f8-ddb3-11e7-933f-3e2ba46783a5.png)
