### PR TITLE
change IPFS gateway so it has a chance of working from https origins

### DIFF
--- a/lib/image.coffee
+++ b/lib/image.coffee
@@ -7,7 +7,7 @@ editor = require './editor'
 resolve = require './resolve'
 
 ipfs = false
-gateway = "//localhost:8080"
+gateway = "http://127.0.0.1:8080"
 $.ajax "#{gateway}/ipfs/Qmb1oS3TaS8vekxXqogoYsixe47sXcVxQ22kPWH8VSd7yQ",
   timeout: 30000
   success: (data) -> ipfs = data == "wiki\n"


### PR DESCRIPTION
The original `gateway` would never work with sites that are hosted from https

The `gateway` value is changed to specify the protocol `http:` and change `localhost` to `127.0.0.1`

We have to use an IP address, rather than `localhost` to avoid content getting blocked with a mixed content warning.