### PR TITLE
remove green halo when forking about pages

### DIFF
--- a/lib/pageHandler.coffee
+++ b/lib/pageHandler.coffee
@@ -173,6 +173,7 @@ pageHandler.put = ($page, action) ->
   delete action.site if action.site == 'origin'
 
   # update dom when forking
+  $page.removeClass('plugin')
   if forkFrom
     # pull remote site closer to us
     $page.find('h1').prop('title',location.host)


### PR DESCRIPTION
We allow edits to about pages which get stored as normal pages as if they were forked from a remote site. We have always meant for the green halo to be removed when this happens but have never made that so until now.

This proper signaling of page location becomes more important because a user can now easily delete the unwanted copy revealing again the distributed plugin documentation.

We don't record implicit forks of about pages. This leaves the Journal a bit cleaner when a plugin author uses this means for revising documentation. Debug and write in the same server then copy pages back to the plugin source before commit.
```
cp ~/.wiki/localhost/pages/about-some-plugin pages
```

![image](https://user-images.githubusercontent.com/12127/35198181-f72890fe-fe9f-11e7-98d0-eeb1b1baa6c3.png)
