### PR TITLE
asset plugin

### DIFF
--- a/lib/addToJournal.coffee
+++ b/lib/addToJournal.coffee
@@ -24,7 +24,7 @@ module.exports = ($journal, action) ->
   if action.type == 'fork' and action.site?
     $action
       .css("background-image", "url(#{wiki.site(action.site).flag()}")
-      .attr("href", "#{wiki.site(action.site).getURL($page.attr('id'))}.html")
+      .attr("href", "#{wiki.site(action.site).getDirectURL($page.attr('id'))}.html")
       .attr("target", "#{action.site}")
       .data("site", action.site)
       .data("slug", $page.attr('id'))

--- a/lib/page.coffee
+++ b/lib/page.coffee
@@ -159,7 +159,7 @@ newPage = (json, site) ->
       "view/welcome-visitors/view/#{slug}"
     if isRemote()
       # "//#{site}/#{path}"
-      wiki.site(site).getURL(path)
+      wiki.site(site).getDirectURL(path)
     else
       "/#{path}"
 

--- a/lib/refresh.coffee
+++ b/lib/refresh.coffee
@@ -137,7 +137,7 @@ handleHeaderClick = (e) ->
     $page = $(e.target).parents('.page:first')
     crumbs = lineup.crumbs $page.data('key'), location.host
     [target, ] = crumbs
-    [prefix, ] = wiki.site(target).getURL('').split('/')
+    [prefix, ] = wiki.site(target).getDirectURL('').split('/')
     if prefix is ''
       prefix = window.location.protocol
     newWindow = window.open "#{prefix}//#{crumbs.join '/'}", target
@@ -184,8 +184,8 @@ emitFooter = ($footer, pageObject) ->
   slug = pageObject.getSlug()
   $footer.append """
     <a id="license" href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank">CC BY-SA 4.0</a> .
-    <a class="show-page-source" href="#{wiki.site(host).getURL(slug)}.json?random=#{random.randomBytes(4)}" title="source">JSON</a> .
-    <a href= "#{wiki.site(host).getURL(slug)}.html" date-slug="#{slug}" target="#{host}">#{host} </a> .
+    <a class="show-page-source" href="#{wiki.site(host).getDirectURL(slug)}.json" title="source">JSON</a> .
+    <a href= "#{wiki.site(host).getDirectURL(slug)}.html" date-slug="#{slug}" target="#{host}">#{host} </a> .
     <a href= "#" class=search>search</a>
   """
 

--- a/lib/siteAdapter.coffee
+++ b/lib/siteAdapter.coffee
@@ -246,12 +246,7 @@ siteAdapter.site = (site) ->
           console.log "#{site} is unreachable, can't link to #{route}"
           ""
         else
-          if /proxy/.test(sitePrefix[site])
-            thisSite = sitePrefix[site].substring(7)
-            thisPrefix = "http://#{thisSite}"
-          else
-            thisPrefix = sitePrefix[site]
-          "#{thisPrefix}/#{route}"
+          "#{sitePrefix[site]}/#{route}"
       else
         # don't yet know how to construct links for site, so find how and fixup
         #findAdapterQ.push {site: site}, (prefix) ->

--- a/lib/siteAdapter.coffee
+++ b/lib/siteAdapter.coffee
@@ -18,6 +18,14 @@ tempFlags = {}
 fetchTimeoutMS = 3000
 findQueueWorkers = 8
 
+console.log "siteAdapter: loading data"
+localForage.iterate (value, key, iterationNumber) ->
+  sitePrefix[key] = value
+.then () ->
+  console.log "siteAdapter: data loaded"
+.catch (err) ->
+  console.log "siteAdapter: error loading data ", err
+
 
 testWikiSite = (url, good, bad) ->
   fetchTimeout = new Promise( (resolve, reject) ->

--- a/lib/siteAdapter.coffee
+++ b/lib/siteAdapter.coffee
@@ -109,6 +109,7 @@ findAdapter = (site, done) ->
 siteAdapter.local = {
   flag: -> "/favicon.png"
   getURL: (route) -> "/#{route}"
+  getDirectURL: (route) -> "/#{route}"
   get: (route, done) ->
     console.log "wiki.local.get #{route}"
     if page = localStorage.getItem(route.replace(/\.json$/,''))
@@ -127,6 +128,7 @@ siteAdapter.local = {
 siteAdapter.origin = {
   flag: -> "/favicon.png"
   getURL: (route) -> "/#{route}"
+  getDirectURL: (route) -> "/#{route}"
   get: (route, done) ->
     console.log "wiki.origin.get #{route}"
     $.ajax
@@ -156,6 +158,7 @@ siteAdapter.origin = {
 siteAdapter.recycler = {
   flag: -> "/recycler/favicon.png"
   getURL: (route) -> "/recycler/#{route}"
+  getDirectURL: (route) -> "/recycler/#{route}"
   get: (route, done) ->
     console.log "wiki.recycler.get #{route}"
     $.ajax
@@ -250,6 +253,34 @@ siteAdapter.site = (site) ->
       else
         # don't yet know how to construct links for site, so find how and fixup
         #findAdapterQ.push {site: site}, (prefix) ->
+        findAdapter site, (prefix) ->
+          if prefix is ""
+            console.log "#{site} is unreachable"
+          else
+            console.log "Prefix for #{site} is #{prefix}, about to fixup links"
+            # add href to journal fork
+            $('a[target="' + site + '"]').each( () ->
+              if /proxy/.test(prefix)
+                thisSite = prefix.substring(7)
+                thisPrefix = "http://#{thisSite}"
+              else
+                thisPrefix = prefix
+              $(this).attr('href', "#{thisPrefix}/#{$(this).data("slug")}.html") )
+        ""
+
+    getDirectURL: (route) ->
+      if sitePrefix[site]?
+        if sitePrefix[site] is ""
+          console.log "#{site} is unreachable, can't link to #{route}"
+          ""
+        else
+          if /proxy/.test(sitePrefix[site])
+            thisSite = sitePrefix[site].substring(7)
+            thisPrefix = "http://#{thisSite}"
+          else
+            thisPrefix = sitePrefix[site]
+          "#{thisPrefix}/#{route}"
+      else
         findAdapter site, (prefix) ->
           if prefix is ""
             console.log "#{site} is unreachable"

--- a/lib/siteAdapter.coffee
+++ b/lib/siteAdapter.coffee
@@ -21,6 +21,7 @@ findQueueWorkers = 8
 console.log "siteAdapter: loading data"
 localForage.iterate (value, key, iterationNumber) ->
   sitePrefix[key] = value
+  return
 .then () ->
   console.log "siteAdapter: data loaded"
 .catch (err) ->

--- a/lib/siteAdapter.coffee
+++ b/lib/siteAdapter.coffee
@@ -211,13 +211,15 @@ siteAdapter.site = (site) ->
     flag: ->
       if sitePrefix[site]?
         if sitePrefix[site] is ""
-          tempFlags[site]
+          if tempFlags[site]?
+            tempFlags[site]
+          else
+            tempFlags[site] = createTempFlag(site)
         else
           # we already know how to construct flag url
           sitePrefix[site] + "/favicon.png"
       else if tempFlags[site]?
         # we already have a temp. flag
-        console.log "wiki.site(#{site}).flag - already has temp. flag"
         tempFlags[site]
       else
         # we don't know the url to the real flag, or have a temp flag

--- a/test/page.coffee
+++ b/test/page.coffee
@@ -5,6 +5,8 @@ wiki = {}
 wiki.site = (site) -> {
   getURL: (route) ->
     "//#{site}/#{route}"
+  getDirectURL: (route) ->
+    "//#{site}/#{route}"
 }
 global.wiki = wiki
 


### PR DESCRIPTION
We extend the site adapter to add `getDirectURL` which gives us the URL to use where a resource is going to be directly accessed, typically used when opening a new window; keeping `getURL` to construct the URL where we are going to access it programatically.

We also update the site adapter so that saved adapter configuration is loaded at start-up.

This is linked with correctly supporting https origins with WardCunningham/wiki-plugin-assets#3