### PR TITLE
add license details to page footer license link

### DIFF
--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -12,6 +12,7 @@ drop = require './drop'
 dialog = require './dialog'
 link = require './link'
 target = require './target'
+license = require './license'
 
 asSlug = require('./page').asSlug
 newPage = require('./page').newPage
@@ -101,6 +102,12 @@ $ ->
     return false
 
   $('.main')
+    .delegate '.show-page-license', 'click', (e) ->
+      e.preventDefault()
+      $page = $(this).parents('.page')
+      title = $page.find('h1').text().trim()
+      dialog.open "License for #{title}", license.info($page)
+
     .delegate '.show-page-source', 'click', (e) ->
       e.preventDefault()
       $page = $(this).parents('.page')

--- a/lib/license.coffee
+++ b/lib/license.coffee
@@ -28,10 +28,10 @@ authors = (page, site) ->
   list = []
   for action in page.journal.slice(0).reverse()
     site = action.site if action.site?
-      unless action.type is 'fork' or done[site]?
-        siteURL = wiki.site(site).getDirectURL("")
-        list.push """<a href="#{siteURL}" target="_blank">#{site}</a>"""
-        done[site] = true
+    unless action.type is 'fork' or done[site]?
+      siteURL = wiki.site(site).getDirectURL("")
+      list.push """<a href="#{siteURL}" target="_blank">#{site}</a>"""
+      done[site] = true
   return "" unless list.length > 0
   """
     <p>

--- a/lib/license.coffee
+++ b/lib/license.coffee
@@ -1,4 +1,4 @@
-# The licence module explains federated wiki licence terms
+# The license module explains federated wiki license terms
 # including the proper attribution of collaborators.
 
 resolve = require './resolve'
@@ -31,7 +31,6 @@ authors = (page, site) ->
     unless action.type is 'fork' or done[site]?
       list.push """<a href="//#{site}">#{site}</a>"""
       done[site] = true
-  console.log 'list',list
   return "" unless list.length > 0
   """
     <p>

--- a/lib/license.coffee
+++ b/lib/license.coffee
@@ -28,9 +28,10 @@ authors = (page, site) ->
   list = []
   for action in page.journal.slice(0).reverse()
     site = action.site if action.site?
-    unless action.type is 'fork' or done[site]?
-      list.push """<a href="//#{site}">#{site}</a>"""
-      done[site] = true
+      unless action.type is 'fork' or done[site]?
+        siteURL = wiki.site(site).getDirectURL("")
+        list.push """<a href="#{siteURL}" target="_blank">#{site}</a>"""
+        done[site] = true
   return "" unless list.length > 0
   """
     <p>

--- a/lib/license.coffee
+++ b/lib/license.coffee
@@ -1,0 +1,63 @@
+# The licence module explains federated wiki licence terms
+# including the proper attribution of collaborators.
+
+resolve = require './resolve'
+lineup = require './lineup'
+
+cc = ->
+  """
+    <p>
+      <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">
+      <img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png" /></a>
+    </p><p>
+      This work is licensed under a
+      <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">
+        Creative Commons Attribution-ShareAlike 4.0 International License
+      </a>.
+    </p><p>
+      This license applies uniformly to all contributions
+      by all authors. Where authors quote other sources
+      they do so within the terms of fair use or other
+      compatiable terms.
+    </p>
+  """
+
+authors = (page, site) ->
+  return "" unless page.journal?
+  done = {}
+  list = []
+  for action in page.journal.slice(0).reverse()
+    site = action.site if action.site?
+    unless action.type is 'fork' or done[site]?
+      list.push """<a href="//#{site}">#{site}</a>"""
+      done[site] = true
+  console.log 'list',list
+  return "" unless list.length > 0
+  """
+    <p>
+      Author's Sites:
+    </p><p>
+      #{list.join "<br>"}
+    </p>
+  """
+
+provenance = (action) ->
+  return "" unless action?.provenance?
+  """
+    <p>
+      Created From:
+    </p><p>
+      #{resolve.resolveLinks action.provenance}
+    </p>
+  """
+
+info = ($page) ->
+  pageObject = lineup.atKey($page.data('key'))
+  page = pageObject.getRawPage()
+  site = pageObject.getRemoteSite location.hostname
+  cc() +
+  authors(page, site) +
+  provenance(page.journal[0])
+
+
+module.exports = {info}

--- a/lib/license.coffee
+++ b/lib/license.coffee
@@ -30,7 +30,8 @@ authors = (page, site) ->
     site = action.site if action.site?
     unless action.type is 'fork' or done[site]?
       siteURL = wiki.site(site).getDirectURL("")
-      list.push """<a href="#{siteURL}" target="_blank">#{site}</a>"""
+      siteFlag = wiki.site(site).flag()
+      list.push """<a href="#{siteURL}" target="_blank"><img class="remote" title="#{site}" src="#{siteFlag}"> #{site}</a>"""
       done[site] = true
   return "" unless list.length > 0
   """

--- a/lib/refresh.coffee
+++ b/lib/refresh.coffee
@@ -183,7 +183,7 @@ emitFooter = ($footer, pageObject) ->
   host = pageObject.getRemoteSite(location.host)
   slug = pageObject.getSlug()
   $footer.append """
-    <a id="license" href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank">CC BY-SA 4.0</a> .
+    <a class="show-page-license" href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank">CC BY-SA 4.0</a> .
     <a class="show-page-source" href="#{wiki.site(host).getDirectURL(slug)}.json" title="source">JSON</a> .
     <a href= "#{wiki.site(host).getDirectURL(slug)}.html" date-slug="#{slug}" target="#{host}">#{host} </a> .
     <a href= "#" class=search>search</a>


### PR DESCRIPTION
@opn reminds us that the attribution from forks in the journal is hidden in read-only mode and no attempt has been made to explain sources entering by transporter.

Here we intercept the previously supplied link to Creative Commons and offer our interpretation of the journal in the context of our chosen license.

We look for non-fork actions and report the sites that they appear to originate at based on subsequent forks or the ultimate owner of the page.

![image](https://user-images.githubusercontent.com/12127/36347130-50e15dc8-1404-11e8-9471-6341902c3452.png)

We look for "provenance" attached to the first action (typically a Create) and render that as wiki text when present. Here I edit .wiki/localhost/pages/welcome-visitors to test this feature.

```
  "journal": [
    {
      "type": "create",
      "item": {
        "title": "Welcome Visitors",
        "story": []
      },
      "date": 1420938191608,
      "provenance": "This page provided by the authors of federated wiki. See [https://github.com/orgs/fedwiki/people github]"
    },
```

![image](https://user-images.githubusercontent.com/12127/36347137-a55e79b2-1404-11e8-8bfc-50241cccc677.png)

### More To Do
- [x] Make proper references to SiteAdapter rather than directly generating links.
- [x] Remove console.log.
- [x] Possibly add site flags to each site mention.

### Won't Do
- [ ] Possibly retrieve the author's name from the who field of welcome-visitors.