### PR TITLE
Splitout and perform any implicit fork

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "6"
   - "8"
   - "10"
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
   - "6"
   - "8"
-  - "9"
+  - "10"
 install:
   - npm install
 before_install:

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -3,7 +3,7 @@ module.exports = function (grunt) {
   grunt.loadNpmTasks('grunt-contrib-watch');
   grunt.loadNpmTasks('grunt-mocha-test');
   grunt.loadNpmTasks('grunt-contrib-clean');
-  grunt.loadNpmTasks('grunt-contrib-uglify');
+  grunt.loadNpmTasks('grunt-contrib-uglify-es');
   grunt.loadNpmTasks('grunt-git-authors');
   grunt.loadNpmTasks('grunt-retire');
   grunt.loadNpmTasks('grunt-nsp');
@@ -108,7 +108,7 @@ module.exports = function (grunt) {
       test: {
         options: {
           reporter: 'spec',
-          require: 'coffee-script/register'
+          require: 'coffeescript/register'
         },
         src: [
           'test/util.coffee',

--- a/lib/pageHandler.coffee
+++ b/lib/pageHandler.coffee
@@ -180,16 +180,22 @@ pageHandler.put = ($page, action) ->
     $page.find('h1 img').attr('src', '/favicon.png')
     $page.find('h1 a').attr('href', "/view/welcome-visitors/view/#{pagePutInfo.slug}").attr('target',location.host)
     $page.data('site', null)
-    $page.removeClass('remote')
+    if forkFrom is 'recycler'
+      $page.removeClass('recycler')
+    else
+      $page.removeClass('remote')
     #STATE -- update url when site changes
     state.setUrl()
     if action.type != 'fork'
-      # bundle implicit fork with next action
-      action.fork = forkFrom
-      addToJournal $page.find('.journal'),
-        type: 'fork'
-        site: forkFrom
-        date: action.date
+      # make the implicit fork, rather than bundling with next action
+      implicit = {}
+      implicit.date = action.date
+      implicit.site = forkFrom unless forkFrom is 'recycler' or null
+      implicit.type = 'fork'
+      await pushToServer($page, pagePutInfo, implicit)
+      .then () -> console.log "Implicit fork performed"
+      action.date = (new Date()).getTime()
+      console.log "next..."
 
   # store as appropriate
   if pageHandler.useLocalStorage() or pagePutInfo.site == 'local'

--- a/package.json
+++ b/package.json
@@ -57,6 +57,6 @@
     "url": "https://github.com/fedwiki/wiki-client/issues"
   },
   "engines": {
-    "node": ">=6.x"
+    "node": ">=8.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,20 +33,20 @@
     "test": "grunt mochaTest"
   },
   "devDependencies": {
-    "coffee-script": "^1.12.4",
-    "coffeeify": "^2.1.0",
+    "coffeeify": "^3.0.1",
+    "coffeescript": "^2.3.1",
     "expect.js": "^0.3.1",
     "grunt": "^1.0.1",
     "grunt-browserify": "^5.2.0",
     "grunt-contrib-clean": "^1.0.0",
-    "grunt-contrib-uglify": "^3.0.1",
+    "grunt-contrib-uglify-es": "^3.3.0",
     "grunt-contrib-watch": "^1.0.0",
     "grunt-git-authors": "^3.2.0",
     "grunt-mocha-test": "^0.13.2",
     "grunt-nsp": "^2.3.1",
     "grunt-retire": "^1.0.3",
-    "mocha": "^3.1.2",
-    "sinon": "^3.2.1"
+    "mocha": "^5.2.0",
+    "sinon": "^6.1.3"
   },
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Here we split out any implicit fork, and perform it, before applying the edit. We also correct the missing update to the current page state (removing the recycler halo). This addresses the case of a page in the `recycler` being edited, which previously with the compound action containing the implicit fork would try and apply to update to the current wiki page, rather than the page in the recycler.

`await` is used to sequence the two actions, this also saves rewriting `pushToServer` and `pushToLocal` to use callbacks and the associated ripple of changes and callback hell.


N.B. This does not address an associated issue with a *ghost* page being edited. Also not sure if this addresses all the potential problems raised in #217 