### PR TITLE
stop fall through

### DIFF
--- a/lib/siteAdapter.coffee
+++ b/lib/siteAdapter.coffee
@@ -330,7 +330,8 @@ siteAdapter.site = (site) ->
                 else
                   credentialsNeeded[site] = false
                   done err, page
-            done null, data
+            else
+              done null, data
           error: (xhr, type, msg) ->
             done {msg, xhr}, null
 


### PR DESCRIPTION
`done` should only be called once, either in `getContent`, or in the else part of the condition.

This correct an error where done is getting called too soon, on the fall through, rather as part of the call back from getContent.