### PR TITLE
add slug search to wiki page footer search options

### DIFF
--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -213,6 +213,10 @@ $ ->
       resultPage.addItem
         type: 'search'
         text: "SEARCH LINKS #{pageObject.getSlug()}"
+      resultPage.addParagraph "Find pages with titles similar to this title."
+      resultPage.addItem
+        type: 'search'
+        text: "SEARCH SLUGS #{pageObject.getSlug()}"
       resultPage.addParagraph "Find pages neighboring  this site."
       resultPage.addItem
         type: 'search'


### PR DESCRIPTION
This seems so obvious but I can't get it to show by adding a revised wiki-client to my localhost server. There should be one more option in this panel.

![image](https://user-images.githubusercontent.com/12127/50730388-48786500-1101-11e9-8ba9-c7c97fc9cba2.png)
