### PR TITLE
dispatch and handle image urls

### DIFF
--- a/lib/drop.coffee
+++ b/lib/drop.coffee
@@ -24,6 +24,11 @@ isPage = (url) ->
     return item
   null
 
+isImage = (url) ->
+  if url.match /\.(jpeg|jpg|png)$/i
+    return url
+  null
+
 isVideo = (url) ->
   parsedURL = nurl.parse(url, true, true)
   # check if video dragged from search (Google)
@@ -68,6 +73,9 @@ dispatch = (handlers) ->
       if video = isVideo url
         if (handle = handlers.video)?
           return stop handle video
+      if image = isImage url
+        if (handle = handlers.image)?
+          return stop handle image
       punt = {url}
     if file = isFile event
       if (handle = handlers.file)?

--- a/lib/factory.coffee
+++ b/lib/factory.coffee
@@ -51,7 +51,6 @@ emit = ($item, item) ->
     showMenu()
   else
     wiki.origin.get 'system/factories.json', (error, data) ->
-      console.log 'factory', data
       window.catalog = data
       showMenu()
 
@@ -91,6 +90,11 @@ bind = ($item, item) ->
   addVideo = (video) ->
     item.type = 'video'
     item.text = "#{video.text}\n(double-click to edit caption)\n"
+    syncEditAction()
+
+  addWebImage = (url) ->
+    item.type = 'image'
+    item.text = "downloaded [#{url.replace(/^https?/,'')} source]"
     syncEditAction()
 
   readFile = (file) ->
@@ -139,6 +143,7 @@ bind = ($item, item) ->
     page: addReference
     file: readFile
     video: addVideo
+    image: addWebImage
     punt: punt
 
 # from http://www.bennadel.com/blog/1504-Ask-Ben-Parsing-CSV-Strings-With-Javascript-Exec-Regular-Expression-Command.htm

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wiki-client",
-  "version": "0.14.3",
+  "version": "0.14.3-exp",
   "description": "Federated Wiki - Client-side Javascript",
   "keywords": [
     "wiki",


### PR DESCRIPTION
UNTESTED WORK IN PROGRESS

Considering https://github.com/fedwiki/wiki/issues/121

There really are times where you want a lot of large images on a page. We've talked about managing images in the assets directory but the logic is complex and remains unimplemented.

This pull request extends Factory to accept a dropped image url and creates an Image item with url set to that string. This makes a lightweight item that will not bloat a page even if the caption is repeatedly edited. Here we assume the image is persistently stored as one might expect from Wikipedia Commons or our own assets directories.

Workflow for adding small Image items:
1. Save image as local file with jpeg, jpg or png suffix.
2. Upload or drag image to Assets item, preferably with markup `page/<slug name of page>`.
3. Click image name to open it in new tab.
4. Drag that tab's location to a Factory to become an Image item.

Workflow for adding html item with img tag:
1. same
2. same
3. Copy Link Address of image name in Assets
4. Create an HTML item with markup like `<img width=100% src=<pasted-image-address.png>>`



