### PR TITLE
Set tabindex of pages and focus them when active.

### DIFF
--- a/client/style/style.css
+++ b/client/style/style.css
@@ -272,10 +272,11 @@ p.readout {
   background-color: white;
   height: 100%;
   overflow: auto;
-  box-shadow: 2px 1px 4px rgba(0, 0, 0, 0.2); }
+  box-shadow: 2px 1px 4px rgba(0, 0, 0, 0.2);
+  outline: none; }
   .page.active {
     box-shadow: 2px 1px 24px rgba(0, 0, 0, 0.4);
-    z-index: 10; outline: none; }
+    z-index: 10; }
 
 .page.plugin > .paper {
   box-shadow: inset 0px 0px 40px 0px rgba(0,220,0,.5);

--- a/client/style/style.css
+++ b/client/style/style.css
@@ -275,7 +275,7 @@ p.readout {
   box-shadow: 2px 1px 4px rgba(0, 0, 0, 0.2); }
   .page.active {
     box-shadow: 2px 1px 24px rgba(0, 0, 0, 0.4);
-    z-index: 10; }
+    z-index: 10; outline: none; }
 
 .page.plugin > .paper {
   box-shadow: inset 0px 0px 40px 0px rgba(0,220,0,.5);

--- a/lib/active.coffee
+++ b/lib/active.coffee
@@ -33,3 +33,4 @@ active.set = ($page) ->
   $page = $($page)
   $(".active").removeClass("active")
   scrollTo $page.addClass("active")
+  $page.focus()

--- a/lib/link.coffee
+++ b/lib/link.coffee
@@ -12,7 +12,7 @@ createPage = (name, loc) ->
   site = loc if loc and loc isnt 'view'
   title = asTitle(name)
   $page = $ """
-    <div class="page" id="#{name}">
+    <div class="page" id="#{name}" tabindex="-1">
       <div class="paper">
         <div class="twins"> <p> </p> </div>
         <div class="header">

--- a/views/static.html
+++ b/views/static.html
@@ -22,7 +22,7 @@
   <body>
     <section class='main'>
       {{#pages}}
-      <div class='page' id='{{page}}' tabindex=-1 {{{origin}}} {{{generated}}}>
+      <div class='page' id='{{page}}' tabindex="-1" {{{origin}}} {{{generated}}}>
         <div class='paper'>
           {{{story}}}
         </div>

--- a/views/static.html
+++ b/views/static.html
@@ -22,7 +22,7 @@
   <body>
     <section class='main'>
       {{#pages}}
-      <div class='page' id='{{page}}' {{{origin}}} {{{generated}}}>
+      <div class='page' id='{{page}}' tabindex=-1 {{{origin}}} {{{generated}}}>
         <div class='paper'>
           {{{story}}}
         </div>


### PR DESCRIPTION
When changing the active page with the left / right arrow keys, the keyboard focus doesn't follow which makes it impossible to scroll the new active page without using the mouse.

This small change enables the page div to be focusable (by setting the tabindex) and then uses this new ability to set the keyboard focus whenever a page is made active.

I chose a tabindex of -1 so pages aren't added to the list of tab selectable elements.