### PR TITLE
Don't propagate editor click events to page.

### DIFF
--- a/lib/editor.coffee
+++ b/lib/editor.coffee
@@ -111,6 +111,7 @@ textEditor = ($item, item, option={}) ->
   $textarea = $("<textarea>#{escape original}#{escape option.suffix ? ''}</textarea>")
     .focusout focusoutHandler
     .bind 'keydown', keydownHandler
+    .click (e) -> e.stopPropagation()
   $item.html $textarea
   if option.caret
     setCaretPosition $textarea, option.caret


### PR DESCRIPTION
This fixes an issue caused by PR #231. When you click in an already active editor to reposition the cursor, the click event propagates up to the parent which calls active.set() which causes the active editor to lose the focus when focus is called on the page.

Here are the ways I can see this issue could be fixed. (This PR goes with option 1):
1. Tell the editor to not allow the event to propagate to the parent.
2. In active.set() change the call to only call focus if there is no element with the .textEditing style present in the DOM.
3. In active.set() don't call focus if the to be activated page is the currently active page.

Options 2 and 3 feel like they are trying to undo something that should not have happened. Option 1 is the only one that prevents the problem from happening in the first place.

I've verified that:
   * focus is still following the active pane when using the arrow keys or when clicking with the mouse
   * editors can still be activated by double clicking
   * the cursor can be repositioned in an active editor using the mouse