### PR TITLE
Prevent flicker and loss of focus from wiki page elements during lineup scrolling

### DIFF
--- a/lib/active.coffee
+++ b/lib/active.coffee
@@ -32,7 +32,9 @@ scrollTo = ($page) ->
   # scroll to target and set focus once animation is complete
   active.scrollContainer.animate({
     scrollLeft: scrollTarget
-    }, () -> $page.focus())
+    }, () ->
+      # only set focus if focus is not already within the page to get focus
+      $page.focus() unless $.contains $page[0], $( document.activeElement ))
 
 
 active.set = ($page) ->

--- a/lib/active.coffee
+++ b/lib/active.coffee
@@ -34,7 +34,7 @@ scrollTo = ($page) ->
     scrollLeft: scrollTarget
     }, () ->
       # only set focus if focus is not already within the page to get focus
-      $page.focus() unless $.contains $page[0], $( document.activeElement ))
+      $page.focus() unless $.contains $page[0], document.activeElement )
 
 
 active.set = ($page) ->

--- a/lib/active.coffee
+++ b/lib/active.coffee
@@ -22,15 +22,20 @@ scrollTo = ($page) ->
   width = $page.outerWidth(true)
   contentWidth = $(".page").outerWidth(true) * $(".page").length
 
+  # determine target position to scroll to...
   if target < minX
-    active.scrollContainer.animate scrollLeft: target
+    scrollTarget = target
   else if target + width > maxX
-    active.scrollContainer.animate scrollLeft: target - (bodyWidth - width)
+    scrollTarget = target - (bodyWidth - width)
   else if maxX > $(".pages").outerWidth()
-    active.scrollContainer.animate scrollLeft: Math.min(target, contentWidth - bodyWidth)
+    scrollTarget = Math.min(target, contentWidth - bodyWidth)
+  # scroll to target and set focus once animation is complete
+  active.scrollContainer.animate({
+    scrollLeft: scrollTarget
+    }, () -> $page.focus())
+
 
 active.set = ($page) ->
   $page = $($page)
   $(".active").removeClass("active")
   scrollTo $page.addClass("active")
-  $page.focus()

--- a/lib/editor.coffee
+++ b/lib/editor.coffee
@@ -111,7 +111,6 @@ textEditor = ($item, item, option={}) ->
   $textarea = $("<textarea>#{escape original}#{escape option.suffix ? ''}</textarea>")
     .focusout focusoutHandler
     .bind 'keydown', keydownHandler
-    .click (e) -> e.stopPropagation()
   $item.html $textarea
   if option.caret
     setCaretPosition $textarea, option.caret

--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -33,7 +33,7 @@ $ ->
     direction = switch event.which
       when LEFTARROW then -1
       when RIGHTARROW then +1
-    if direction && not (event.target.tagName is "TEXTAREA")
+    if direction && not $(event.target).is(":input")
       pages = $('.page')
       newIndex = pages.index($('.active')) + direction
       if 0 <= newIndex < pages.length
@@ -266,7 +266,7 @@ $ ->
       resultPage.addParagraph """
         Installed plugins offer these utility pages:
       """
-      return unless window.catalog 
+      return unless window.catalog
 
       titles = []
       for info in window.catalog


### PR DESCRIPTION
Fixes #233 

Changes to how we set page focus, so that it is only done after the page scrolling animation is complete (to prevent flicker), and if focus is not already set within the current wiki page.