### PR TITLE
Drag to reorder pages

### DIFF
--- a/client/style/style.css
+++ b/client/style/style.css
@@ -102,9 +102,6 @@ header {
 .header > h1 {
   cursor: grab; }
 
-.ui-sortable-helper .header > h1 {
-  cursor: grabbing; }
-
 footer {
   bottom: 0; }
 

--- a/client/style/style.css
+++ b/client/style/style.css
@@ -102,6 +102,9 @@ header {
 .header > h1 {
   cursor: grab; }
 
+.ui-sortable-helper .header > h1 {
+  cursor: grabbing; }
+
 footer {
   bottom: 0; }
 

--- a/client/style/style.css
+++ b/client/style/style.css
@@ -313,6 +313,19 @@ p.readout {
   top: 0px;
 }
 
+div.page-draggable.page {
+  box-shadow: 2px 1px 24px rgba(255, 250, 153, 0.4);
+  transition-property: box-shadow;
+  transition-duration: 300ms;
+}
+
+/* make more specific than ghost style. */
+div.pending-remove.page {
+  opacity: 0.2;
+  transition-property: opacity;
+  transition-duration: 300ms;
+}
+
 .twins span {
   z-index: 2;
   position: relative;

--- a/client/style/style.css
+++ b/client/style/style.css
@@ -99,7 +99,7 @@ img.remote,
 header {
   top: 0; }
 
-.header span {
+.page-handle {
   cursor: grab; }
 
 footer {
@@ -116,14 +116,6 @@ footer {
 .footer:hover {
   opacity: 1;
 }
-
-.header > h1 {
-  display: table; }
-
-.header > h1 > span {
-  width: 100%;
-  display: table-cell;
-  padding-left: 5px; }
 
 .story {
   padding-bottom: 5px; }
@@ -309,6 +301,26 @@ p.readout {
   /*width: 430px;*/
   padding: 30px;
   min-height: 100%;
+  z-index: 0;
+  position: relative;
+}
+
+.page-handle {
+  z-index: 1;
+  width: 100%;
+  position: absolute;
+  left: 0px;
+  top: 0px;
+}
+
+.twins span {
+  z-index: 2;
+  position: relative;
+}
+
+.header span {
+  z-index: 2;
+  position: relative;
 }
 
 .factory,

--- a/client/style/style.css
+++ b/client/style/style.css
@@ -117,6 +117,14 @@ footer {
   opacity: 1;
 }
 
+.header > h1 {
+  display: table; }
+
+.header > h1 > span {
+  width: 100%;
+  display: table-cell;
+  padding-left: 5px; }
+
 .story {
   padding-bottom: 5px; }
 

--- a/client/style/style.css
+++ b/client/style/style.css
@@ -99,6 +99,9 @@ img.remote,
 header {
   top: 0; }
 
+.header > h1 {
+  cursor: grab; }
+
 footer {
   bottom: 0; }
 

--- a/client/style/style.css
+++ b/client/style/style.css
@@ -99,7 +99,7 @@ img.remote,
 header {
   top: 0; }
 
-.header > h1 {
+.header span {
   cursor: grab; }
 
 footer {

--- a/client/style/style.css
+++ b/client/style/style.css
@@ -301,6 +301,9 @@ p.readout {
   /*width: 430px;*/
   padding: 30px;
   min-height: 100%;
+}
+
+.handle-parent {
   z-index: 0;
   position: relative;
 }

--- a/lib/active.coffee
+++ b/lib/active.coffee
@@ -37,7 +37,8 @@ scrollTo = ($page) ->
       $page.focus() unless $.contains $page[0], document.activeElement )
 
 
-active.set = ($page) ->
+active.set = ($page, noScroll) ->
   $page = $($page)
   $(".active").removeClass("active")
-  scrollTo $page.addClass("active")
+  $page.addClass("active")
+  scrollTo $page unless noScroll

--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -104,6 +104,7 @@ $ ->
     return false
 
   $('.main')
+    .sortable().on('sortupdate', state.setUrl)
     .delegate '.show-page-license', 'click', (e) ->
       e.preventDefault()
       $page = $(this).parents('.page')

--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -104,7 +104,7 @@ $ ->
     return false
 
   $('.main')
-    .sortable({axis: 'x', handle: '.header'})
+    .sortable({axis: 'x', handle: '.header', cursor: 'grabbing'})
       .on 'sortstart', (e, ui) ->
         noScroll = true
         active.set ui.item, noScroll

--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -104,7 +104,7 @@ $ ->
     return false
 
   $('.main')
-    .sortable({axis: 'x', handle: '.header', cursor: 'grabbing'})
+    .sortable({axis: 'x', handle: '.header span', cursor: 'grabbing'})
       .on 'sortstart', (e, ui) ->
         noScroll = true
         active.set ui.item, noScroll

--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -105,11 +105,22 @@ $ ->
 
   $('.main')
     .sortable({handle: '.header span', cursor: 'grabbing'})
-      .on 'sortstart', (e, ui) ->
+      .on 'sortstart', (evt, ui) ->
         noScroll = true
         active.set ui.item, noScroll
-      .on 'sortstop', (e, ui) ->
-        if e.pageY < 0
+      .on 'sort', (evt, ui) ->
+        $page = ui.item
+        if evt.pageY < 0
+          if not $page.hasClass('pending-remove')
+            $page.addClass('pending-remove')
+              .animate({opacity: 0.2}, 300)
+        else
+          if $page.hasClass('pending-remove')
+            $page.removeClass('pending-remove')
+              .animate({opacity: 1.0}, 300)
+
+      .on 'sortstop', (evt, ui) ->
+        if ui.item.hasClass('pending-remove')
           $pages = $('.page')
           return if $pages.length == 1
           index = $pages.index($('.active'))

--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -106,9 +106,11 @@ $ ->
   $('.main')
     .sortable({handle: '.page-handle', cursor: 'grabbing'})
       .on 'sortstart', (evt, ui) ->
+        return if not ui.item.hasClass('.page')
         noScroll = true
         active.set ui.item, noScroll
       .on 'sort', (evt, ui) ->
+        return if not ui.item.hasClass('.page')
         $page = ui.item
         # Only mark for removal if there's more than one page (+placeholder) left
         if evt.pageY < 0 and $(".page").length > 2
@@ -117,6 +119,7 @@ $ ->
           $page.removeClass('pending-remove')
 
       .on 'sortstop', (evt, ui) ->
+        return if not ui.item.hasClass('.page')
         $pages = $('.page')
         index = $pages.index($('.active'))
         if ui.item.hasClass('pending-remove')

--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -109,7 +109,7 @@ $ ->
         noScroll = true
         active.set ui.item, noScroll
       .on 'sortstop', (e, ui) ->
-        if ui.position.top < 0
+        if e.pageY < 0
           $pages = $('.page')
           return if $pages.length == 1
           index = $pages.index($('.active'))

--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -120,16 +120,19 @@ $ ->
               .animate({opacity: 1.0}, 300)
 
       .on 'sortstop', (evt, ui) ->
+        $pages = $('.page')
+        index = $pages.index($('.active'))
         if ui.item.hasClass('pending-remove')
-          $pages = $('.page')
           return if $pages.length == 1
-          index = $pages.index($('.active'))
           index = index - 1 if $pages.length - 1 == index
+          lineup.removeKey(ui.item.data('key'))
           ui.item.remove()
           active.set($('.page')[index])
         else
+          lineup.changePageIndex(ui.item.data('key'), index)
           active.set $('.active')
         state.setUrl()
+        state.debugStates()
 
     .delegate '.show-page-license', 'click', (e) ->
       e.preventDefault()

--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -112,13 +112,9 @@ $ ->
         $page = ui.item
         # Only mark for removal if there's more than one page (+placeholder) left
         if evt.pageY < 0 and $(".page").length > 2
-          if not $page.hasClass('pending-remove')
-            $page.addClass('pending-remove')
-              .animate({opacity: 0.2}, 300)
+          $page.addClass('pending-remove')
         else
-          if $page.hasClass('pending-remove')
-            $page.removeClass('pending-remove')
-              .animate({opacity: 1.0}, 300)
+          $page.removeClass('pending-remove')
 
       .on 'sortstop', (evt, ui) ->
         $pages = $('.page')

--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -104,7 +104,14 @@ $ ->
     return false
 
   $('.main')
-    .sortable().on('sortupdate', state.setUrl)
+    .sortable({axis: 'x'})
+      .on 'sortstart', (e, ui) ->
+        noScroll = true
+        active.set ui.item, noScroll
+      .on 'sortstop', () ->
+        state.setUrl()
+        active.set $('.active')
+
     .delegate '.show-page-license', 'click', (e) ->
       e.preventDefault()
       $page = $(this).parents('.page')

--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -104,7 +104,7 @@ $ ->
     return false
 
   $('.main')
-    .sortable({axis: 'x'})
+    .sortable({axis: 'x', handle: '.header'})
       .on 'sortstart', (e, ui) ->
         noScroll = true
         active.set ui.item, noScroll

--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -104,7 +104,7 @@ $ ->
     return false
 
   $('.main')
-    .sortable({handle: '.header span', cursor: 'grabbing'})
+    .sortable({handle: '.page-handle', cursor: 'grabbing'})
       .on 'sortstart', (evt, ui) ->
         noScroll = true
         active.set ui.item, noScroll

--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -106,11 +106,11 @@ $ ->
   $('.main')
     .sortable({handle: '.page-handle', cursor: 'grabbing'})
       .on 'sortstart', (evt, ui) ->
-        return if not ui.item.hasClass('.page')
+        return if not ui.item.hasClass('page')
         noScroll = true
         active.set ui.item, noScroll
       .on 'sort', (evt, ui) ->
-        return if not ui.item.hasClass('.page')
+        return if not ui.item.hasClass('page')
         $page = ui.item
         # Only mark for removal if there's more than one page (+placeholder) left
         if evt.pageY < 0 and $(".page").length > 2
@@ -119,7 +119,7 @@ $ ->
           $page.removeClass('pending-remove')
 
       .on 'sortstop', (evt, ui) ->
-        return if not ui.item.hasClass('.page')
+        return if not ui.item.hasClass('page')
         $pages = $('.page')
         index = $pages.index($('.active'))
         if ui.item.hasClass('pending-remove')

--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -104,13 +104,21 @@ $ ->
     return false
 
   $('.main')
-    .sortable({axis: 'x', handle: '.header span', cursor: 'grabbing'})
+    .sortable({handle: '.header span', cursor: 'grabbing'})
       .on 'sortstart', (e, ui) ->
         noScroll = true
         active.set ui.item, noScroll
-      .on 'sortstop', () ->
+      .on 'sortstop', (e, ui) ->
+        if ui.position.top < 0
+          $pages = $('.page')
+          return if $pages.length == 1
+          index = $pages.index($('.active'))
+          index = index - 1 if $pages.length - 1 == index
+          ui.item.remove()
+          active.set($('.page')[index])
+        else
+          active.set $('.active')
         state.setUrl()
-        active.set $('.active')
 
     .delegate '.show-page-license', 'click', (e) ->
       e.preventDefault()

--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -110,7 +110,8 @@ $ ->
         active.set ui.item, noScroll
       .on 'sort', (evt, ui) ->
         $page = ui.item
-        if evt.pageY < 0
+        # Only mark for removal if there's more than one page (+placeholder) left
+        if evt.pageY < 0 and $(".page").length > 2
           if not $page.hasClass('pending-remove')
             $page.addClass('pending-remove')
               .animate({opacity: 0.2}, 300)

--- a/lib/lineup.coffee
+++ b/lib/lineup.coffee
@@ -18,6 +18,12 @@ addPage = (pageObject) ->
   keyByIndex.push key
   return key
 
+changePageIndex = (key, newIndex) ->
+  oldIndex = keyByIndex.indexOf key
+  page = keyByIndex[oldIndex]
+  keyByIndex.splice(oldIndex, 1)
+  keyByIndex.splice(newIndex, 0, page)
+
 removeKey = (key) ->
   return null unless key in keyByIndex
   keyByIndex = keyByIndex.filter (each) -> key != each
@@ -86,4 +92,4 @@ crumbs = (key, location) ->
   result
 
 
-module.exports = {addPage, removeKey, removeAllAfterKey, atKey, titleAtKey, bestTitle, debugKeys, debugReset, crumbs, debugSelfCheck}
+module.exports = {addPage, changePageIndex, removeKey, removeAllAfterKey, atKey, titleAtKey, bestTitle, debugKeys, debugReset, crumbs, debugSelfCheck}

--- a/lib/lineup.coffee
+++ b/lib/lineup.coffee
@@ -20,9 +20,8 @@ addPage = (pageObject) ->
 
 changePageIndex = (key, newIndex) ->
   oldIndex = keyByIndex.indexOf key
-  page = keyByIndex[oldIndex]
   keyByIndex.splice(oldIndex, 1)
-  keyByIndex.splice(newIndex, 0, page)
+  keyByIndex.splice(newIndex, 0, key)
 
 removeKey = (key) ->
   return null unless key in keyByIndex

--- a/lib/refresh.coffee
+++ b/lib/refresh.coffee
@@ -242,8 +242,9 @@ renderPageIntoPageElement = (pageObject, $page) ->
   $page.empty()
   $paper = $("<div class='paper' />")
   $page.append($paper)
-  [$pagehandle, $twins, $header, $story, $journal, $footer] = ['page-handle', 'twins', 'header', 'story', 'journal', 'footer'].map (className) ->
-    $("<div />").addClass(className).appendTo($paper) if className != 'journal' or $('.editEnable').is(':visible')
+  [$handleParent, $twins, $header, $story, $journal, $footer] = ['handle-parent', 'twins', 'header', 'story', 'journal', 'footer'].map (className) ->
+    $('<div />').addClass(className).appendTo($paper) if className != 'journal' or $('.editEnable').is(':visible')
+  $pagehandle = $('<div />').addClass('page-handle').appendTo($handleParent)
   $pagehandle.on('mouseenter', () => $page.addClass('page-draggable'))
   $pagehandle.on('mouseleave', () => $page.removeClass('page-draggable'))
 

--- a/lib/refresh.coffee
+++ b/lib/refresh.coffee
@@ -265,7 +265,9 @@ renderPageIntoPageElement = (pageObject, $page) ->
   emitTwins $page
   emitControls $journal if $('.editEnable').is(':visible')
   emitFooter $footer, pageObject
-  $pagehandle.css({height: "#{$story.position().top-5}px"})
+  $pagehandle.css({
+    height: "#{$story.position().top-$handleParent.position().top-5}px"
+  })
 
 
 createMissingFlag = ($page, pageObject) ->

--- a/lib/refresh.coffee
+++ b/lib/refresh.coffee
@@ -244,8 +244,8 @@ renderPageIntoPageElement = (pageObject, $page) ->
   $page.append($paper)
   [$pagehandle, $twins, $header, $story, $journal, $footer] = ['page-handle', 'twins', 'header', 'story', 'journal', 'footer'].map (className) ->
     $("<div />").addClass(className).appendTo($paper) if className != 'journal' or $('.editEnable').is(':visible')
-  $pagehandle.on('mouseenter', () => $page.css('opacity', 0.8))
-  $pagehandle.on('mouseleave', () => $page.css('opacity', 1))
+  $pagehandle.on('mouseenter', () => $page.addClass('page-draggable'))
+  $pagehandle.on('mouseleave', () => $page.removeClass('page-draggable'))
 
   emitHeader $header, $page, pageObject
   emitTimestamp $header, $page, pageObject

--- a/lib/refresh.coffee
+++ b/lib/refresh.coffee
@@ -152,9 +152,11 @@ emitHeader = ($header, $page, pageObject) ->
   tooltip = pageObject.getRemoteSiteDetails location.host
   $header.append """
     <h1 title="#{tooltip}">
-      <a href="#{pageObject.siteLineup()}" target="#{remote}">
-        <img src="#{wiki.site(remote).flag()}" height="32px" class="favicon"></a>
-      <span>#{resolve.escape pageObject.getTitle()}</span>
+      <span>
+        <a href="#{pageObject.siteLineup()}" target="#{remote}">
+          <img src="#{wiki.site(remote).flag()}" height="32px" class="favicon"></a>
+        #{resolve.escape pageObject.getTitle()}
+      </span>
     </h1>
   """
   $header.find('a').on 'click', handleHeaderClick
@@ -226,7 +228,7 @@ emitTwins = ($page) ->
           title="#{remoteSite}">
         """
       twins.push "#{flags.join '&nbsp;'} #{legend}"
-    $page.find('.twins').html """<p>#{twins.join ", "}</p>""" if twins
+    $page.find('.twins').html """<p><span>#{twins.join ", "}</span></p>""" if twins
 
 renderPageIntoPageElement = (pageObject, $page) ->
   $page.data("data", pageObject.getRawPage())
@@ -240,8 +242,10 @@ renderPageIntoPageElement = (pageObject, $page) ->
   $page.empty()
   $paper = $("<div class='paper' />")
   $page.append($paper)
-  [$twins, $header, $story, $journal, $footer] = ['twins', 'header', 'story', 'journal', 'footer'].map (className) ->
+  [$pagehandle, $twins, $header, $story, $journal, $footer] = ['page-handle', 'twins', 'header', 'story', 'journal', 'footer'].map (className) ->
     $("<div />").addClass(className).appendTo($paper) if className != 'journal' or $('.editEnable').is(':visible')
+  $pagehandle.on('mouseenter', () => $page.css('opacity', 0.8))
+  $pagehandle.on('mouseleave', () => $page.css('opacity', 1))
 
   emitHeader $header, $page, pageObject
   emitTimestamp $header, $page, pageObject
@@ -260,6 +264,7 @@ renderPageIntoPageElement = (pageObject, $page) ->
   emitTwins $page
   emitControls $journal if $('.editEnable').is(':visible')
   emitFooter $footer, pageObject
+  $pagehandle.css({height: "#{$story.position().top-5}px"})
 
 
 createMissingFlag = ($page, pageObject) ->

--- a/lib/refresh.coffee
+++ b/lib/refresh.coffee
@@ -154,7 +154,7 @@ emitHeader = ($header, $page, pageObject) ->
     <h1 title="#{tooltip}">
       <a href="#{pageObject.siteLineup()}" target="#{remote}">
         <img src="#{wiki.site(remote).flag()}" height="32px" class="favicon"></a>
-      #{resolve.escape pageObject.getTitle()}
+      <span>#{resolve.escape pageObject.getTitle()}</span>
     </h1>
   """
   $header.find('a').on 'click', handleHeaderClick

--- a/lib/state.coffee
+++ b/lib/state.coffee
@@ -35,6 +35,10 @@ state.setUrl = ->
     unless url is $(location).attr('pathname')
       history.pushState(null, null, url)
 
+state.debugStates = () ->
+  console.log 'a .page keys ', ($(each).data('key') for each in $('.page'))
+  console.log 'a lineup keys', lineup.debugKeys()
+
 state.show = (e) ->
   oldPages = state.pagesInDom()
   newPages = state.urlPages()
@@ -56,8 +60,7 @@ state.show = (e) ->
     console.log 'push', idx, name
     link.showPage(name, newLocs[idx])
 
-  console.log 'a .page keys ', ($(each).data('key') for each in $('.page'))
-  console.log 'a lineup keys', lineup.debugKeys()
+  state.debugStates()
 
   active.set($('.page').last())
   document.title = lineup.bestTitle()


### PR DESCRIPTION
This PR enables pages to be reorder by dragging them. The URL is updated to the new lineup once a page has been dropped.

A couple of implementation notes:
* I was unable to find a way to prevent the user from dragging infinitely to the right. After the first checkin, it was possible to be stranded on the far right without any way to scroll back to content. The second checkin fixes that by scrolling the dropped page back into view.
* A new parameter was added to active.set to allow the active page to be set without immediately scrolling to it. This prevents some odd scrolling back and forth scrolling behaviors in longer lineups where pages are partially obscured.

A desired future addition is to allow pages to be removed by swiping up or down. That may change some of the implementation details here, but I feel the current changes provide value as-is.