### PR TITLE
Rework copy and move item user experience.

### DIFF
--- a/client/style/style.css
+++ b/client/style/style.css
@@ -28,6 +28,10 @@ body {
   line-height: 1.3;
   color: #333333; }
 
+/* Better align sortable items. */
+.ui-sortable-helper > p {
+  margin: 0px; }
+
 .main {
   top: 0;
   left: 0;

--- a/lib/refresh.coffee
+++ b/lib/refresh.coffee
@@ -122,7 +122,7 @@ initDragging = ($page) ->
           zIndex: ''
         ).removeAttr('data-id')
     .on 'sortover', (e, ui) ->
-      if ui.sender
+      if ui.sender and ui.sender[0] != e.target
         ui.item.addClass('copy-capable')
       else
         ui.item.removeClass('copy-capable')

--- a/lib/refresh.coffee
+++ b/lib/refresh.coffee
@@ -119,9 +119,15 @@ initDragging = ($page) ->
     delay: 150
   $story = $page.find('.story')
   originalOrder = null
+  dragCancelled = null
+  cancelDrag = (e) ->
+    dragCancelled = true
+    $story.sortable('cancel') if e.which == 27
   $story.sortable(options)
     .on 'sortstart', (e, ui) ->
       originalOrder = getStoryItemOrder($story)
+      dragCancelled = false
+      $('body').on('keydown', cancelDrag)
       # Create a copy that we control since sortable removes theirs too early.
       # Insert after the placeholder to prevent adding history when item not moved.
       # Clear out the styling they add. Updates to jquery ui can affect this.
@@ -134,8 +140,8 @@ initDragging = ($page) ->
         ).removeAttr('data-id')
     .on 'sort', changeMouseCursor
     .on 'sortstop', (e, ui) ->
-      $('body').css('cursor', origCursor)
-      handleDrop(e, ui, originalOrder)
+      $('body').css('cursor', origCursor).off('keydown', cancelDrag)
+      handleDrop(e, ui, originalOrder) unless dragCancelled
       $('.shadow-copy').remove()
 
 getPageObject = ($journal) ->

--- a/lib/refresh.coffee
+++ b/lib/refresh.coffee
@@ -133,9 +133,9 @@ initDragging = ($page) ->
           zIndex: ''
         ).removeAttr('data-id')
     .on 'sort', changeMouseCursor
-    .on 'sortstop', (e, ui) -> handleDrop(e, ui, originalOrder)
     .on 'sortstop', (e, ui) ->
       $('body').css('cursor', origCursor)
+      handleDrop(e, ui, originalOrder)
       $('.shadow-copy').remove()
 
 getPageObject = ($journal) ->

--- a/lib/refresh.coffee
+++ b/lib/refresh.coffee
@@ -114,6 +114,7 @@ initDragging = ($page) ->
     connectWith: '.page .story'
     placeholder: 'item-placeholder'
     forcePlaceholderSize: true
+    delay: 150
   $story = $page.find('.story')
   $story.sortable(options)
     .on 'sortstart', (e, ui) ->


### PR DESCRIPTION
This PR changes the mouse cursor when reordering items within a page or moving / copying between pages based. They also give the user some visual feedback when performing a copy.

These changes likely need some burn in time before they can be committed. I'm starting the PR now to get feedback and gives others the opportunity to try them out. I don't have them hosted anywhere at the moment. I may need to spend some time tweaking my hosting setup so I can host different wikis running different versions of the codebase. I'm limited to one-ish right now.

Changes:
* Use the copy cursor when shift is held down.
* When the copy cursor is shown, show the original item on the source page.
* Use the move cursor by default.
* Do not show the copy cursor when on source page.
* Tweak mouse offset on dragged items.

This does not add a "copy item" entry into the journal. I'm not even sure we have that concept. If needed, I can investigate adding that.

I'm also tempted to rework the code a bit more as the sortable API already has callbacks for some of the states we are manually computing. It may make the code a bit easier to follow.

I have not tested the move or copy semantics related to ghost pages that I see in the code. I may need someone to do this or walk me through the intent behind that code path.

There are probably other things I'm missing.