### PR TITLE
site adapter promises

### DIFF
--- a/lib/siteAdapter.coffee
+++ b/lib/siteAdapter.coffee
@@ -122,7 +122,9 @@ siteAdapter.local = {
   flag: -> "/favicon.png"
   getURL: (route) -> "/#{route}"
   getDirectURL: (route) -> "/#{route}"
-  get: (route, done) ->
+  get: (route, callback) ->
+    done = (err, value) -> if (callback) then callback(err, value)
+
     console.log "wiki.local.get #{route}"
     if page = localStorage.getItem(route.replace(/\.json$/,''))
       done null, JSON.parse page
@@ -141,7 +143,8 @@ siteAdapter.origin = {
   flag: -> "/favicon.png"
   getURL: (route) -> "/#{route}"
   getDirectURL: (route) -> "/#{route}"
-  get: (route, done) ->
+  get: (route, callback) ->
+    done = (err, value) -> if (callback) then callback(err, value)
     console.log "wiki.origin.get #{route}"
     $.ajax
       type: 'GET'
@@ -171,7 +174,8 @@ siteAdapter.recycler = {
   flag: -> "/recycler/favicon.png"
   getURL: (route) -> "/recycler/#{route}"
   getDirectURL: (route) -> "/recycler/#{route}"
-  get: (route, done) ->
+  get: (route, callback) ->
+    done = (err, value) -> if (callback) then callback(err, value)
     console.log "wiki.recycler.get #{route}"
     $.ajax
       type: 'GET'
@@ -310,7 +314,9 @@ siteAdapter.site = (site) ->
               $(this).attr('href', "#{thisPrefix}/#{$(this).data("slug")}.html") )
         ""
 
-    get: (route, done) ->
+    get: (route, callback) ->
+      done = (err, value) -> if (callback) then callback(err, value)
+
       getContent = (route, done) ->
         url = "#{sitePrefix[site]}/#{route}"
         useCredentials = credentialsNeeded[site] || false

--- a/lib/siteAdapter.coffee
+++ b/lib/siteAdapter.coffee
@@ -127,9 +127,14 @@ siteAdapter.local = {
 
     console.log "wiki.local.get #{route}"
     if page = localStorage.getItem(route.replace(/\.json$/,''))
-      done null, JSON.parse page
+      parsedPage = JSON.parse page
+      done null, parsedPage
+      Promise.resolve(parsedPage)
     else
-      done {msg: "no page named '#{route}' in browser local storage"}
+      errMsg = {msg: "no page named '#{route}' in browser local storage"}
+      done errMsg, null
+      console.log("tried to local fetch a page that isn't local")
+      Promise.reject(errMsg)
   put: (route, data, done) ->
     console.log "wiki.local.put #{route}"
     localStorage.setItem(route, JSON.stringify(data))
@@ -344,7 +349,9 @@ siteAdapter.site = (site) ->
       if sitePrefix[site]?
         if sitePrefix[site] is ""
           console.log "#{site} is unreachable"
-          done {msg: "#{site} is unreachable", xhr: {status: 0}}, null
+          errMsg = {msg: "#{site} is unreachable", xhr: {status: 0}}
+          done errMsg, null
+          Promise.reject(errMsg)
         else
           getContent route, done
       else
@@ -352,7 +359,9 @@ siteAdapter.site = (site) ->
         findAdapter site, (prefix) ->
           if prefix is ""
             console.log "#{site} is unreachable"
-            done {msg: "#{site} is unreachable", xhr: {status: 0}}, null
+            errMsg = {msg: "#{site} is unreachable", xhr: {status: 0}}
+            done errMsg, null
+            Promise.reject(errMsg)
           else
             getContent route, done
 


### PR DESCRIPTION
Paired with @WardCunningham on this.

We are using the returned jquery ajax promises in wiki-plugin-graphviz, this PR makes it unnecessary to pass in a dummy callback, and makes all siteAdapter get methods work with promises the same way the graphviz plugin assumes they do.