### PR TITLE
Restore browser test page

### DIFF
--- a/test/neighborhood.coffee
+++ b/test/neighborhood.coffee
@@ -46,7 +46,7 @@ describe 'neighborhood', ->
       expect( searchResult.finds ).to.eql( expectedResult )
 
 
-    it 'searches both the slug and the title'
+    it.skip 'searches both the slug and the title'
 
   describe 'more than one neighbor', ->
     before ->
@@ -83,4 +83,4 @@ describe 'neighborhood', ->
       searchResult = neighborhood.search( "some search query" )
       expect( searchResult.finds ).to.be.empty()
 
-    it 'should re-populate the neighbor'
+    it.skip 'should re-populate the neighbor'

--- a/test/page.coffee
+++ b/test/page.coffee
@@ -1,16 +1,19 @@
 newPage = require('../lib/page').newPage
 expect = require 'expect.js'
 
-wiki = {}
-wiki.site = (site) -> {
-  getURL: (route) ->
-    "//#{site}/#{route}"
-  getDirectURL: (route) ->
-    "//#{site}/#{route}"
-}
-global.wiki = wiki
 
 describe 'page', ->
+
+
+  before () ->
+    wiki = {}
+    wiki.site = (site) -> {
+      getURL: (route) ->
+        "//#{site}/#{route}"
+      getDirectURL: (route) ->
+        "//#{site}/#{route}"
+    }
+    global.wiki = wiki
 
   describe 'newly created', ->
 

--- a/test/pageHandler.coffee
+++ b/test/pageHandler.coffee
@@ -24,6 +24,42 @@ describe 'pageHandler.get', ->
     journal: []
   }
 
+  beforeEach () ->
+    wiki = {}
+    wiki.local = {
+      get: (route, done) ->
+        done {msg: "no page named '#{route}' in browser local storage"}
+    }
+    wiki.origin = {
+      get: (route, done) ->
+        $.ajax
+          type: 'GET'
+          dataType: 'json'
+          url: "/#{route}"
+          success: (page) -> done null, page
+          error: (xhr, type, msg) -> done {msg, xhr}, null
+      put: (route, data, done) ->
+        $.ajax
+          type: 'PUT'
+          url: "/page/#{route}/action"
+          data:
+            'action': JSON.stringify(data)
+          success: () -> done null
+          error: (xhr, type, msg) -> done {xhr, type, msg}
+    }
+    wiki.site = (site) -> {
+      get: (route, done) ->
+        url = "//#{site}/#{route}"
+        $.ajax
+          type: 'GET'
+          dataType: 'json'
+          url: url
+          success: (data) -> done null, data
+          error: (xhr, type, msg) ->
+            done {msg, xhr}, null
+    }
+    global.wiki = wiki
+
   describe 'ajax fails', ->
 
     before ->
@@ -70,7 +106,7 @@ describe 'pageHandler.get', ->
       expect(whenGotten.calledOnce).to.be.true
       expect(jQuery.ajax.calledOnce).to.be.true
       expect(jQuery.ajax.args[0][0]).to.have.property('type', 'GET')
-      expect(jQuery.ajax.args[0][0].url).to.match(///^//siteName/slugName\.json\?random=[a-z0-9]{8}$///)
+      expect(jQuery.ajax.args[0][0].url).to.match(///^//siteName/slugName\.json///)
 
     after ->
       jQuery.ajax.restore()
@@ -86,10 +122,10 @@ describe 'pageHandler.get', ->
         whenGotten: sinon.stub()
         whenNotGotten: sinon.stub()
 
-      expect(jQuery.ajax.args[0][0].url).to.match(///^/slugName\.json\?random=[a-z0-9]{8}$///)
-      expect(jQuery.ajax.args[1][0].url).to.match(///^//example.com/slugName\.json\?random=[a-z0-9]{8}$///)
-      expect(jQuery.ajax.args[2][0].url).to.match(///^//asdf.test/slugName\.json\?random=[a-z0-9]{8}$///)
-      expect(jQuery.ajax.args[3][0].url).to.match(///^//foo.bar/slugName\.json\?random=[a-z0-9]{8}$///)
+      expect(jQuery.ajax.args[0][0].url).to.match(///^/slugName\.json///)
+      expect(jQuery.ajax.args[1][0].url).to.match(///^//example.com/slugName\.json///)
+      expect(jQuery.ajax.args[2][0].url).to.match(///^//asdf.test/slugName\.json///)
+      expect(jQuery.ajax.args[3][0].url).to.match(///^//foo.bar/slugName\.json///)
 
     after ->
       jQuery.ajax.restore()

--- a/test/refresh.coffee
+++ b/test/refresh.coffee
@@ -3,30 +3,67 @@ lineup = require('../lib/lineup')
 mockServer = require('./mockServer')
 
 describe 'refresh', ->
-  simulatePageNotBeingFound = ->
-    sinon.stub(jQuery, "ajax").yieldsTo('success', {title: 'asdf'})
 
   $page = undefined
 
-  before ->
-    $page = $('<div id="refresh" />')
-    $page.appendTo('body')
-  after ->
-    $page.empty()
-    jQuery.ajax.restore()
+  beforeEach ->
+    wiki = {}
+    wiki.local = {
+      get: (route, done) ->
+        done {msg: "no page named '#{route}' in browser local storage"}
+    }
+    wiki.origin = {
+      get: (route, done) ->
+        $.ajax
+          type: 'GET'
+          dataType: 'json'
+          url: "/#{route}"
+          success: (page) -> done null, page
+          error: (xhr, type, msg) -> done {msg, xhr}, null
+    }
+    wiki.site = (site) -> {
+      flag: () ->
+        "//#{site}/favicon.png"
+      getDirectURL: (route) ->
+        "//#{site}/#{route}"
+      get: (route, done) ->
+        url = "//#{site}/#{route}"
+        $.ajax
+          type: 'GET'
+          dataType: 'json'
+          url: url
+          success: (data) -> done null, data
+          error: (xhr, type, msg) ->
+            done {msg, xhr}, null
+    }
+    global.wiki = wiki
 
-  it "creates a ghost page when page couldn't be found", ->
-    mockServer.simulatePageNotFound()
-    $page.each refresh.cycle
-    expect( $page.hasClass('ghost') ).to.be(true)
-    expect( key = $page.data('key') ).to.be.a('string')
-    expect( pageObject = lineup.atKey(key) ).to.be.an('object')
-    expect( pageObject.getRawPage().story[0].type ).to.be('future')
+  describe 'when page not found', ->
 
-  xit 'should refresh a page', (done) ->
-    simulatePageFound({title: 'asdf'})
-    $page.each refresh.cycle
-    jQuery.ajax.restore()
+    before ->
+      $page = $('<div id="ghost" />')
+      $page.appendTo('body')
+      mockServer.simulatePageNotFound()
+    after ->
+      jQuery.ajax.restore()
 
-    expect($('#refresh h1').text()).to.be(' asdf')
-    done()
+    it "creates a ghost page", ->
+      $page.each refresh.cycle
+      expect( $page.hasClass('ghost') ).to.be(true)
+      expect( key = $page.data('key') ).to.be.a('string')
+      expect( pageObject = lineup.atKey(key) ).to.be.an('object')
+      expect( pageObject.getRawPage().story[0].type ).to.be('future')
+
+  describe 'when page found', ->
+
+    before ->
+      $page = $('<div id="refresh" />')
+      $page.appendTo('body')
+      mockServer.simulatePageFound({title: 'asdf'})
+    after ->
+      jQuery.ajax.restore()
+
+    it 'should refresh a page', (done) ->
+      $page.each refresh.cycle
+      expect($('#refresh h1').text().trim()).to.be('asdf')
+      done()

--- a/test/search.coffee
+++ b/test/search.coffee
@@ -3,7 +3,7 @@ createSearch = require '../lib/search'
 describe 'search', ->
   # Can't test for right now, because performing a search
   # does DOM manipulation to build a page, which fails in the test runner. We'd like to isolate that DOM manipulation, but can't right now.
-  xit 'performs a search on the neighborhood', ->
+  it.skip 'performs a search on the neighborhood', ->
     spyNeighborhood = {
       search: sinon.stub().returns([])
     }


### PR DESCRIPTION
For some reason this was over looked when the siteAdapter was created. Here we add mocking of the siteAdapter calls, so that the existing tests run.