### PR TITLE
Allow ESC to save editor.

### DIFF
--- a/lib/editor.coffee
+++ b/lib/editor.coffee
@@ -32,6 +32,11 @@ textEditor = ($item, item, option={}) ->
 
   keydownHandler = (e) ->
 
+    if e.which == 27 #esc for save
+      e.preventDefault()
+      $textarea.focusout()
+      return false
+
     if (e.altKey || e.ctlKey || e.metaKey) and e.which == 83 #alt-s for save
       e.preventDefault()
       $textarea.focusout()


### PR DESCRIPTION
Request from the group in Dayton to allow ESC to be used to close editors in addition to the current cmd/alt-s key combination.