### PR TITLE
expose lineup so plugins can access models

### DIFF
--- a/lib/wiki.coffee
+++ b/lib/wiki.coffee
@@ -171,5 +171,7 @@ wiki.security = require './security'
 
 wiki.createSynopsis = require('./synopsis') ##
 
+# known uses: (none yet)
+wiki.lineup = require './lineup'
 
 module.exports = wiki


### PR DESCRIPTION
We hold page json as js object in two places, `$page.data('data')` and in pageObjects in the lineup. The later is the preferred version but it turns out neither are updated as pages are edited. Here we make the singleton lineup available to plugins so that pageObjects become available and can benefit from anticipated improvements.

With this change the few places that require accurate page json will use 
```
wiki.lineup.atKey($page.data('key'))
```
which will eventually be maintained consistent with the server.

With this change in mind we examine where we might assume that pageObject is already kept current. It turns out not many places but there could be more.

- Legacy: show page source, revision
- Future: some crazy logic that will return to a transporter for more content
- License: some crazy logic that lists authors for CC BY-SA 4.0 link
- PageHandler: fork, pushToLocal (bug)
- Refresh: renderPageIntoElement

So here is the unlikely bug scenario in PageHandler: someone has been successfully editing a page, they lose network connectivity, their next edit causes a pushToLocalStorage, there edits have been lost. Joshua tells me he has experienced this bug while authoring page on the commuter train.