### PR TITLE
Help wiki-server discover static page templates

### DIFF
--- a/lib/views.coffee
+++ b/lib/views.coffee
@@ -1,0 +1,3 @@
+P = require 'path'
+module.exports.path = ->
+  P.join(__dirname, '..', 'views')


### PR DESCRIPTION
Partial fix for incompatibility with `pnpm` which Glitch.com uses to install npm packages.

There is a small, related change coming in a sibling PR for `wiki-server`:
https://github.com/fedwiki/wiki-server/pull/147