### PR TITLE
Help wiki-server discover static page templates

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,3 @@
+// wiki-client is a pure client-side app
+// this entrypoint lets wiki-server discover the location of /views
+module.exports = {}


### PR DESCRIPTION
Enables wiki-server to use `require.resolve('wiki-client')` to find the location of `wiki-client` on disk specifically so express.js can use the `views/static.html` and `views/oops.html` to render pages on the server.

This is an alternative to #244