### PR TITLE
Prevent duplicate plugin loads using promises

### DIFF
--- a/lib/plugin.coffee
+++ b/lib/plugin.coffee
@@ -35,7 +35,7 @@ getScript = plugin.getScript = (url, callback = () ->) ->
         scripts.push url
         callback()
       .fail (_jqXHR, _textStatus, err) ->
-        console.log('Failed to load plugin:', url, err)
+        console.log('getScript: Failed to load:', url, err)
         callback()
 
 plugin.get = plugin.getPlugin = (name, callback) ->

--- a/lib/plugin.coffee
+++ b/lib/plugin.coffee
@@ -12,10 +12,10 @@ escape = (s) ->
     .replace(/'/g, '&#x27;')
     .replace(/\//g,'&#x2F;')
 
-# define cachedScript that allows fetching a cached script.
+# define loadScript that allows fetching a script.
 # see example in http://api.jquery.com/jQuery.getScript/
 
-cachedScript = (url, options) ->
+loadScript = (url, options) ->
   options = $.extend(options or {},
     dataType: "script"
     cache: true
@@ -24,24 +24,34 @@ cachedScript = (url, options) ->
   $.ajax options
 
 scripts = []
+loadingScripts = {}
 getScript = plugin.getScript = (url, callback = () ->) ->
   # console.log "URL :", url, "\nCallback :", callback
   if url in scripts
     callback()
   else
-    cachedScript url
+    loadScript url
       .done ->
         scripts.push url
         callback()
-      .fail ->
+      .fail (_jqXHR, _textStatus, err) ->
+        console.log('Failed to load plugin:', url, err)
         callback()
 
 plugin.get = plugin.getPlugin = (name, callback) ->
-  return callback(window.plugins[name]) if window.plugins[name]
-  getScript "/plugins/#{name}/#{name}.js", () ->
-    return callback(window.plugins[name]) if window.plugins[name]
-    getScript "/plugins/#{name}.js", () ->
-      callback(window.plugins[name])
+  return loadingScripts[name].then(callback) if loadingScripts[name]
+  loadingScripts[name] = new Promise (resolve, _reject) ->
+    return resolve(window.plugins[name]) if window.plugins[name]
+    getScript "/plugins/#{name}/#{name}.js", () ->
+      p = window.plugins[name]
+      return resolve(p) if p
+      getScript "/plugins/#{name}.js", () ->
+        p = window.plugins[name]
+        return resolve(p)
+  loadingScripts[name].then (plugin) ->
+    delete loadingScripts[name]
+    return callback(plugin)
+  return loadingScripts[name]
 
 plugin.do = plugin.doPlugin = (div, item, done=->) ->
   error = (ex, script) ->


### PR DESCRIPTION
This PR resolves a race condition which was leading to plugins getting loaded multiple times. Promises are a really nice fit here. Eric is going to build on this to add support for plugins that use ES6 modules.

The changes are live on fed.wiki.randombits.xyz if you want to take a look.

FYI: @WardCunningham, @paul90, @dobbs.