### PR TITLE
guard against nulls

### DIFF
--- a/lib/resolve.coffee
+++ b/lib/resolve.coffee
@@ -9,7 +9,7 @@ module.exports = resolve = {}
 resolve.resolutionContext = []
 
 resolve.escape = escape = (string) ->
-  string
+  (string||'')
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
@@ -52,7 +52,7 @@ resolve.resolveLinks = (string, sanitize=escape) ->
   #   - remaining text is sanitized and/or escaped
   #   - unique markers are replaced with unstashed links
 
-  string = string
+  string = (string||'')
     .replace /〖(\d+)〗/g, "〖 $1 〗"
     .replace /\[\[([^\]]+)\]\]/gi, internal
     .replace /\[((http|https|ftp):.*?) (.*?)\]/gi, external


### PR DESCRIPTION
We can't be sure that page json is well formed. Instead we must make safe assumptions when we find unexpected nulls or undefined. 

```
  wiki-client/lib/resolve.coffee:58
     string = string.replace(/〖(\d+)〗/g, "〖 $1 〗")...
 TypeError: Cannot read property 'replace' of undefined
```