### PR TITLE
Order plugin bind operations based on declared dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,6 @@ npm-debug.log
 build
 
 # ignore generated javascript - recreated by running grunt
-lib/*.js
-lib/*.map
 test/*.js
 test/*.map
 client/client.js

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -3,7 +3,7 @@ module.exports = function (grunt) {
   grunt.loadNpmTasks('grunt-contrib-watch');
   grunt.loadNpmTasks('grunt-mocha-test');
   grunt.loadNpmTasks('grunt-contrib-clean');
-  grunt.loadNpmTasks('grunt-contrib-uglify');
+  grunt.loadNpmTasks('grunt-contrib-uglify-es');
   grunt.loadNpmTasks('grunt-git-authors');
   grunt.loadNpmTasks('grunt-retire');
 

--- a/client/style/style.css
+++ b/client/style/style.css
@@ -242,7 +242,7 @@ footer {
 .target {
   background-color: #ffffcc !important; }
 
-.consuming {
+.consumed {
   outline: solid 2px orange !important; }
 
 .report p,

--- a/client/style/style.css
+++ b/client/style/style.css
@@ -233,9 +233,17 @@ footer {
 .button:active {
   box-shadow: inset 0 0 7px #3d3c43; }
 
+.output-item {
+  background-color:#eee;
+  padding:15px;
+  margin-block-start:1em;
+  margin-block-end:1em; }
 
 .target {
   background-color: #ffffcc !important; }
+
+.consuming {
+  outline: solid 2px orange !important; }
 
 .report p,
 .factory p,

--- a/lib/editor.coffee
+++ b/lib/editor.coffee
@@ -110,11 +110,9 @@ textEditor = ($item, item, option={}) ->
     else
       unless option.after
         pageHandler.put $page, {type: 'remove', id: item.id}
-      produces = plugin.produces($item)
-      name = $item.data("item").type
       index = $(".item").index($item)
       $item.remove()
-      plugin.notifyConsumers(name, produces, index)
+      plugin.renderFrom index
     null
 
   return if $item.hasClass 'textEditing'

--- a/lib/editor.coffee
+++ b/lib/editor.coffee
@@ -96,6 +96,10 @@ textEditor = ($item, item, option={}) ->
     $textarea.unbind()
     $page = $item.parents('.page:first')
     if item[option.field||'text'] = $textarea.val()
+      # Remove output and source styling as type may have changed.
+      $item.removeClass("output-item")
+      $item.removeClass (_index, className) ->
+        return (className.match(/\S+-source/) || []).join " "
       plugin.do $item.empty(), item
       if option.after
         return if item[option.field||'text'] == ''

--- a/lib/editor.coffee
+++ b/lib/editor.coffee
@@ -106,7 +106,11 @@ textEditor = ($item, item, option={}) ->
     else
       unless option.after
         pageHandler.put $page, {type: 'remove', id: item.id}
+      produces = plugin.produces($item)
+      name = $item.data("item").type
+      index = $(".item").index($item)
       $item.remove()
+      plugin.notifyConsumers(name, produces, index)
     null
 
   return if $item.hasClass 'textEditing'

--- a/lib/forward.js
+++ b/lib/forward.js
@@ -93,7 +93,7 @@ function registerHandler({sConsumer, cProducer, socket}) {
 let eventProcessors = {}
 function init($item, item, processEvent) {
   let bound = withSocket.then((socket) => {
-    let $page = $item.parents('.page')
+    let page = $item.parents('.page').data('key')
     let slug = $page.attr('id').split('_')[0]
     let id = item.id
 

--- a/lib/forward.js
+++ b/lib/forward.js
@@ -93,7 +93,10 @@ function registerHandler({sConsumer, cProducer, socket}) {
 let eventProcessors = {}
 function init($item, item, processEvent) {
   let bound = withSocket.then((socket) => {
-    let {page, slug, id} = $item[0].service()
+    let $page = $item.parents('.page')
+    let slug = $page.attr('id').split('_')[0]
+    let id = item.id
+
     let cProducer = `${page}/${id}`
     let sConsumer = `${slug}/${id}`
     eventProcessors[cProducer] = processEvent

--- a/lib/forward.js
+++ b/lib/forward.js
@@ -1,0 +1,106 @@
+function pageFor(pageKey) {
+  let $page = $('.page').filter((_i, page) => $(page).data('key') == pageKey)
+  if ($page.length == 0) return null
+  if ($page.length > 1) console.log('warning: more than one page found for', key, $page)
+  return $page[0]
+}
+
+function itemElemFor(pageItem) {
+  let [pageKey, item] = pageItem.split('/')
+  let page = pageFor(pageKey)
+  if(!page) return null
+  let $item = $(page).find(`.item[data-id=${item}]`)
+  if ($item.length == 0) return null
+  if ($item.length > 1) console.log('warning: more than one item found for', pageItem, $item)
+  return $item[0]
+}
+
+function slugItemFor(itemElem) {
+  let slug = $(itemElem).parents('.page:first').attr('id').split('_')[0]
+  let id = $(itemElem).attr('data-id')
+  let slugItem = `${slug}/${id}`
+  return slugItem
+}
+
+// map of client producers keyed by server consumers
+// client producers are identified by their pageItem
+// server consumers are identified by their slugItem
+const cProducers = {}
+const sConsumers = []
+var withSocket = new Promise((resolve, reject) => {
+  $.getScript('/socket.io/socket.io.js').done(() => {
+    console.log('socket.io loaded successfully!')
+    var socket = io()
+    socket.on('reconnect', () => {
+      console.log('reconnected: reregistering client side listeners', sConsumers)
+      sConsumers.forEach(sConsumer => {
+        // only need to inform the server since client side listeners survive a disconnect
+        socket.emit('subscribe', sConsumer)
+      })
+    })
+    window.socket = socket
+    resolve(socket)
+  }).fail(() => {
+    console.log('unable to load socket.io')
+    reject(Error('unable to load socket.io'))
+  })
+})
+
+function listener({slugItem, result}) {
+  let sConsumer = slugItem
+  let missing = []
+  cProducers[sConsumer].forEach(cProducer => {
+    let [pageKey, item] = cProducer.split('/')
+    let itemElem = itemElemFor(cProducer)
+    if (!itemElem) {
+      missing.push(cProducer)
+      return
+    }
+    eventProcessors[cProducer]($(itemElem), cProducer, result)
+  })
+  missing.forEach(cProducer => {
+    // The item for the producer has been moved or removed, unregister the listener.
+    console.log("Removing client side listener for", cProducer)
+    cProducers[sConsumer].splice(cProducers[sConsumer].indexOf(cProducer), 1)
+    eventProcessors[cProducer] = null
+    if (cProducers[sConsumer].length == 0) {
+      delete cProducers[sConsumer]
+      console.log('Removing server side listener for', sConsumer)
+      sConsumers.splice(sConsumers.indexOf(sConsumer), 1)
+      withSocket.then(socket => {
+        // stop listening and tell the server to stop sending
+        socket.off(sConsumer, listener)
+        socket.emit('unsubscribe', sConsumer)
+      })
+    }
+  })
+}
+
+function registerHandler({sConsumer, cProducer, socket}) {
+  if (!cProducers[sConsumer]) cProducers[sConsumer] = []
+  if (sConsumers.indexOf(sConsumer) == -1) {
+    sConsumers.push(sConsumer)
+    console.log(`subscribing to ${sConsumer}`, sConsumers)
+    socket.on(sConsumer, listener)
+    socket.emit('subscribe', sConsumer)
+  }
+  if (cProducers[sConsumer].indexOf(cProducer) == -1) {
+    cProducers[sConsumer].push(cProducer)
+    console.log('adding producer', cProducer, cProducers)
+  }
+}
+
+let eventProcessors = {}
+function init($item, item, processEvent) {
+  let bound = withSocket.then((socket) => {
+    let {page, slug, id} = $item[0].service()
+    let cProducer = `${page}/${id}`
+    let sConsumer = `${slug}/${id}`
+    eventProcessors[cProducer] = processEvent
+    return {sConsumer, cProducer, socket}
+  })
+  bound.then(registerHandler)
+}
+
+module.exports = {init}
+

--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -343,7 +343,6 @@ $ ->
         active.set($('.page').last())
         return
       $page = $(pages.shift())
-      refresh.cycle($page).then ([emitp, bindp]) ->
-        Promise.all([emitp, bindp]).then ->
-          renderNextPage(pages)
+      refresh.cycle($page).then () ->
+        renderNextPage(pages)
     renderNextPage(pages)

--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -104,12 +104,14 @@ $ ->
     link.doInternalLink name, page, $(e.target).data('site')
     return false
 
+  originalFirstItemIndex = null
   $('.main')
     .sortable({handle: '.page-handle', cursor: 'grabbing'})
       .on 'sortstart', (evt, ui) ->
         return if not ui.item.hasClass('page')
         noScroll = true
         active.set ui.item, noScroll
+        originalFirstItemIndex = $(".item").index(ui.item.find(".item")[0])
       .on 'sort', (evt, ui) ->
         return if not ui.item.hasClass('page')
         $page = ui.item
@@ -125,6 +127,8 @@ $ ->
         $pages = $('.page')
         index = $pages.index($('.active'))
         firstItemIndex = $(".item").index($page.find(".item")[0])
+        if originalFirstItemIndex < firstItemIndex
+          firstItemIndex = originalFirstItemIndex
         if $page.hasClass('pending-remove')
           return if $pages.length == 1
           affectedPlugins = $page.find(".item").map (_i, e) ->

--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -104,14 +104,14 @@ $ ->
     link.doInternalLink name, page, $(e.target).data('site')
     return false
 
-  originalFirstItemIndex = null
+  originalPageIndex = null
   $('.main')
     .sortable({handle: '.page-handle', cursor: 'grabbing'})
       .on 'sortstart', (evt, ui) ->
         return if not ui.item.hasClass('page')
         noScroll = true
         active.set ui.item, noScroll
-        originalFirstItemIndex = $(".item").index(ui.item.find(".item")[0])
+        originalPageIndex = $(".page").index(ui.item[0])
       .on 'sort', (evt, ui) ->
         return if not ui.item.hasClass('page')
         $page = ui.item
@@ -126,28 +126,19 @@ $ ->
         $page = ui.item
         $pages = $('.page')
         index = $pages.index($('.active'))
-        firstItemIndex = $(".item").index($page.find(".item")[0])
-        if originalFirstItemIndex < firstItemIndex
-          firstItemIndex = originalFirstItemIndex
+        firstItemIndex = $('.item').index($page.find('.item')[0])
         if $page.hasClass('pending-remove')
           return if $pages.length == 1
-          affectedPlugins = $page.find(".item").map (_i, e) ->
-            $item = $(e)
-            name = $item.data("item").type
-            return {name, produces: plugin.produces($item)}
-          index = index - 1 if $pages.length - 1 == index
           lineup.removeKey($page.data('key'))
           $page.remove()
           active.set($('.page')[index])
-          affectedPlugins.map (_i, {name, produces}) ->
-            plugin.notifyConsumers(name, produces, firstItemIndex)
         else
           lineup.changePageIndex($page.data('key'), index)
           active.set $('.active')
-          $page.find(".item").each (_i, e) ->
-            $item = $(e)
-            item = $item.data("item")
-            plugin.do $item.empty(), item, (->), firstItemIndex
+          if originalPageIndex < index
+            index = originalPageIndex
+            firstItemIndex = $('.item').index($($('.page')[index]).find('.item')[0])
+        plugin.renderFrom firstItemIndex
         state.setUrl()
         state.debugStates()
 

--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -210,7 +210,8 @@ $ ->
         lineup.removeAllAfterKey(key) unless e.shiftKey
         link.createPage("#{slug}_rev#{rev}", $page.data('site'))
           .appendTo($('.main'))
-          .each refresh.cycle
+          .each (_i, e) ->
+            refresh.cycle $(e)
         active.set($('.page').last())
 
     .delegate '.fork-page', 'click', (e) ->

--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -325,5 +325,9 @@ $ ->
 
   $ ->
     state.first()
-    $('.page').each refresh.cycle
+    promise = Promise.resolve()
+    $('.page').each ->
+      $page = $(this)
+      promise = promise.then ->
+        refresh.cycle $page
     active.set($('.page').last())

--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -106,7 +106,7 @@ $ ->
 
   originalPageIndex = null
   $('.main')
-    .sortable({handle: '.page-handle', cursor: 'grabbing'})
+    .sortable({handle: '.page-handle', cursor: 'grabbing', cancel: 'journal'})
       .on 'sortstart', (evt, ui) ->
         return if not ui.item.hasClass('page')
         noScroll = true

--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -106,7 +106,7 @@ $ ->
 
   originalPageIndex = null
   $('.main')
-    .sortable({handle: '.page-handle', cursor: 'grabbing', cancel: 'journal'})
+    .sortable({handle: '.page-handle', cursor: 'grabbing'})
       .on 'sortstart', (evt, ui) ->
         return if not ui.item.hasClass('page')
         noScroll = true

--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -343,11 +343,13 @@ $ ->
 
   $ ->
     state.first()
-    bindp = Promise.resolve()
-    emitp = Promise.resolve()
-    emitps = []
-    $('.page').each ->
-      $page = $(this)
-      [emitp, bindp] = refresh.cycle $page, Promise.all(emitps), bindp
-      emitps.push(emitp)
-    active.set($('.page').last())
+    pages = $('.page').toArray()
+    renderNextPage = (pages) ->
+      if pages.length == 0
+        active.set($('.page').last())
+        return
+      $page = $(pages.shift())
+      refresh.cycle($page).then ([emitp, bindp]) ->
+        Promise.all([emitp, bindp]).then ->
+          renderNextPage(pages)
+    renderNextPage(pages)

--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -344,6 +344,9 @@ $ ->
   $ ->
     state.first()
     pages = $('.page').toArray()
+    # Render pages in order
+    # Emits and "bind creations" for the previous page must be complete before we start
+    # rendering the next page or plugin bind ordering will not work
     renderNextPage = (pages) ->
       if pages.length == 0
         active.set($('.page').last())

--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -343,9 +343,11 @@ $ ->
 
   $ ->
     state.first()
-    promise = Promise.resolve()
+    bindp = Promise.resolve()
+    emitp = Promise.resolve()
+    emitps = []
     $('.page').each ->
       $page = $(this)
-      promise = promise.then ->
-        refresh.cycle $page
+      [emitp, bindp] = refresh.cycle $page, Promise.all(emitps), bindp
+      emitps.push(emitp)
     active.set($('.page').last())

--- a/lib/link.coffee
+++ b/lib/link.coffee
@@ -25,7 +25,7 @@ createPage = (name, loc) ->
   $page
 
 showPage = (name, loc) ->
-  createPage(name, loc).appendTo('.main').each refresh.cycle
+  createPage(name, loc).appendTo('.main').each((_i, e) -> refresh.cycle($(e)))
 
 doInternalLink = (name, $page, site=null) ->
   name = asSlug(name)

--- a/lib/page.coffee
+++ b/lib/page.coffee
@@ -121,10 +121,12 @@ newPage = (json, site) ->
     return null
 
   seqItems = (each) ->
-    emitItem = (i) ->
-      return if i >= page.story.length
-      each page.story[i]||{text:'null'}, -> emitItem i+1
-    emitItem 0
+    promise = new Promise (resolve, _reject) ->
+      emitItem = (i) ->
+        return resolve() if i >= page.story.length
+        each page.story[i]||{text:'null'}, -> emitItem i+1
+      emitItem 0
+    return promise
 
   addParagraph = (text) ->
     type = "paragraph"

--- a/lib/plugin.coffee
+++ b/lib/plugin.coffee
@@ -107,6 +107,10 @@ bind = (name, pluginBind) ->
         console.log 'plugin emit: unexpected error', e
   return fn
 
+plugin.wrap = (name, p) ->
+  p.bind = bind(name, p.bind)
+  return p
+
 plugin.get = plugin.getPlugin = (name, callback) ->
   return loadingScripts[name].then(callback) if loadingScripts[name]
   loadingScripts[name] = new Promise (resolve, _reject) ->
@@ -114,11 +118,11 @@ plugin.get = plugin.getPlugin = (name, callback) ->
     getScript "/plugins/#{name}/#{name}.js", () ->
       p = window.plugins[name]
       if p
-        p.bind = bind(name, p.bind)
+        plugin.wrap(name, p)
         return resolve(p)
       getScript "/plugins/#{name}.js", () ->
         p = window.plugins[name]
-        p.bind = bind(name, p.bind) if p
+        plugin.wrap(name, p) if p
         return resolve(p)
   loadingScripts[name].then (plugin) ->
     delete loadingScripts[name]

--- a/lib/plugin.coffee
+++ b/lib/plugin.coffee
@@ -100,6 +100,7 @@ bind = (name, pluginBind) ->
           forward.init $item, item, window.plugins[name].processServerEvent
       # After we bind, notify everyone that depends on us to reload
       .then ->
+        console.log('notifying consumers')
         produces = plugin.produces($item)
         plugin.notifyConsumers(name, produces, notifIndex)
       .catch (e) ->

--- a/lib/plugin.coffee
+++ b/lib/plugin.coffee
@@ -96,6 +96,8 @@ bind = (name, pluginBind) ->
         $item[0].promise = bindPromise
         console.log("promise bound for", name)
       .then ->
+        # If the plugin has the needed callback, subscribe to server side events
+        # for the current page
         if window.plugins[name].processServerEvent
           console.log 'listening for server events', $item, item
           forward.init $item, item, window.plugins[name].processServerEvent

--- a/lib/plugin.coffee
+++ b/lib/plugin.coffee
@@ -92,6 +92,7 @@ bind = (name, pluginBind) ->
         bindPromise = pluginBind($item, item)
         if not bindPromise or typeof(bindPromise.then) == 'function'
           bindPromise = Promise.resolve(bindPromise)
+        # This is where the "bind results" promise for the current item is stored
         $item[0].promise = bindPromise
         console.log("promise bound for", name)
       .then ->

--- a/lib/plugin.coffee
+++ b/lib/plugin.coffee
@@ -102,7 +102,22 @@ bind = (name, pluginBind) ->
       .then ->
         console.log('notifying consumers')
         produces = plugin.produces($item)
+        if $item[0].sources
+          # notify consumers of previous sources, if needed
+          notifyPrevious = false
+          for source in $item[0].sources
+            if source not in produces
+              console.log("plugin no longer produces #{source}")
+              notifyPrevious = true
+          plugin.notifyConsumers(name, $item[0].sources, notifIndex) if notifyPrevious
         plugin.notifyConsumers(name, produces, notifIndex)
+      .then ->
+        # Save off current list of sources so we can detect removal later
+        $item[0].sources = $item[0]
+          .className
+          .split " "
+          .map (c) -> '.' + c
+          .filter (c) -> c.match(/.*-source/)
       .catch (e) ->
         console.log 'plugin emit: unexpected error', e
   return fn

--- a/lib/plugin.coffee
+++ b/lib/plugin.coffee
@@ -57,8 +57,8 @@ plugin.notifyConsumers = (name, produces, notifIndex) ->
     tonotify = pluginsThatConsume(producer)
     console.log(producer, "is consumed by", tonotify)
     tonotify.forEach (name) ->
-      instances = $(".item:gt(#{notifIndex-1})").filter("." + name)
-      console.log("there are #{instances.length} instances of #{name} beyond index #{notifIndex-1}")
+      instances = $(".item:gt(#{notifIndex})").filter("." + name)
+      console.log("there are #{instances.length} instances of #{name} beyond index #{notifIndex}")
       instances.each (_i, consumer) ->
         $consumer = $(consumer)
         plugin.do $consumer.empty(), $consumer.data("item")

--- a/lib/plugin.coffee
+++ b/lib/plugin.coffee
@@ -16,6 +16,7 @@ escape = (s) ->
 # see example in http://api.jquery.com/jQuery.getScript/
 
 loadScript = (url, options) ->
+  console.log("loading url:", url)
   options = $.extend(options or {},
     dataType: "script"
     cache: true
@@ -61,10 +62,19 @@ bind = (name, pluginBind) ->
         if not producers or producers.length == 0
           console.log 'warn: no items in lineup that produces', consuming
         console.log("there are #{producers.length} instances of #{consuming}")
-        deps.concat(producers.map (_i, el) -> el.promise)
+        producers.each (_i, el) ->
+          console.log("promise: ", el, el.promise)
+          deps.push(el.promise)
+      console.log("waiting for:", deps)
       waitFor = Promise.all(deps)
     waitFor
-      .then pluginBind($item, item)
+      .then ->
+        console.log("getting promise for", name)
+        bindPromise = pluginBind($item, item)
+        if not bindPromise or typeof(bindPromise.then) == 'function'
+          bindPromise = Promise.resolve(bindPromise)
+        $item[0].promise = bindPromise
+        console.log("promise bound for", name)
       # After we bind, notify everyone that depends on us to reload
       .then ->
         produces = $item[0].className.split(" ")

--- a/lib/plugin.coffee
+++ b/lib/plugin.coffee
@@ -39,36 +39,8 @@ getScript = plugin.getScript = (url, callback = () ->) ->
         console.log('getScript: Failed to load:', url, err)
         callback()
 
-# Consumes is a list
-pluginsThatConsume = (capability) ->
-  Object.keys(window.plugins)
-    .filter (plugin) -> window.plugins[plugin].consumes
-    .filter (plugin) -> window.plugins[plugin].consumes.indexOf(capability) != -1
-
-plugin.produces = ($item) ->
-  produces = $item[0].className.split(" ")
-    .filter (c) -> c.indexOf("-source") != -1
-    .map (c) -> "." + c
-  return produces
-
 plugin.renderFrom = (notifIndex) ->
-  # (name, produces, notifIndex) ->
-  #return if produces.length == 0 
   $items = $(".item").slice(notifIndex)
-  # Possible optimization...
-  #tonotify = []
-  #produces.forEach (producer) ->
-  #  tonotify = tonotify.concat(pluginsThatConsume(producer))
-  #  console.log(producer, "is consumed by", tonotify)
-  #console.log "need to notify", tonotify
-
-  #consumers = []
-  #for item in items.toArray()
-  #  for name in tonotify
-  #    if item.className.indexOf(name) != -1
-  #      consumers.push(item)
-
-  #console.log "notifIndex", notifIndex, "about to notify", $items
   
   console.log "notifIndex", notifIndex, "about to render", $items
   emitp = Promise.resolve()
@@ -170,10 +142,10 @@ plugin.get = plugin.getPlugin = (name, callback) ->
   return loadingScripts[name]
 
 
-plugin.do = plugin.doPlugin = (div, item, done=->, originalIndex) ->
-  plugin.emit div, item, {done, originalIndex, bind: true}
+plugin.do = plugin.doPlugin = (div, item, done=->) ->
+  plugin.emit div, item, {done, bind: true}
 
-plugin.emit = (div, item, {done=->, originalIndex, bind=false}) ->
+plugin.emit = (div, item, {done=->, bind=false}) ->
   error = (ex, script) ->
     div.append """
       <div class="error">
@@ -206,11 +178,11 @@ plugin.emit = (div, item, {done=->, originalIndex, bind=false}) ->
       $('.retry').on 'click', ->
         if script.emit.length > 2
           script.emit div, item, ->
-            script.bind div, item, originalIndex if bind
+            script.bind div, item if bind
             done()
         else
           script.emit div, item
-          script.bind div, item, originalIndex if bind
+          script.bind div, item if bind
           done()
 
   div.data 'pageElement', div.parents(".page")
@@ -220,11 +192,11 @@ plugin.emit = (div, item, {done=->, originalIndex, bind=false}) ->
       throw TypeError("Can't find plugin for '#{item.type}'") unless script?
       if script.emit.length > 2
         script.emit div, item, ->
-          script.bind div, item, originalIndex if bind
+          script.bind div, item if bind
           done()
       else
         script.emit div, item
-        script.bind div, item, originalIndex if bind
+        script.bind div, item if bind
         done()
     catch err
       console.log 'plugin error', err

--- a/lib/plugin.coffee
+++ b/lib/plugin.coffee
@@ -42,7 +42,7 @@ getScript = plugin.getScript = (url, callback = () ->) ->
 pluginsThatConsume = (capability) ->
   Object.keys(window.plugins)
     .filter (plugin) -> window.plugins[plugin].consumes
-    .filter (plugin) -> Object.keys(window.plugins[plugin].consumes).indexOf(capability) != -1
+    .filter (plugin) -> window.plugins[plugin].consumes.indexOf(capability) != -1
 
 plugin.produces = ($item) ->
   produces = $item[0].className.split(" ")
@@ -73,7 +73,7 @@ bind = (name, pluginBind) ->
     # before calling our bind method.
     if consumes
       deps = []
-      Object.keys(consumes).forEach (consuming) ->
+      consumes.forEach (consuming) ->
         producers = $(".item:lt(#{index})").filter(consuming)
         console.log(name, "consumes", consuming)
         console.log(producers, "produce", consuming)

--- a/lib/plugin.coffee
+++ b/lib/plugin.coffee
@@ -39,7 +39,7 @@ getScript = plugin.getScript = (url, callback = () ->) ->
         console.log('getScript: Failed to load:', url, err)
         callback()
 
-# Consumes is a map
+# Consumes is a list
 pluginsThatConsume = (capability) ->
   Object.keys(window.plugins)
     .filter (plugin) -> window.plugins[plugin].consumes

--- a/lib/plugin.coffee
+++ b/lib/plugin.coffee
@@ -93,19 +93,15 @@ bind = (name, pluginBind) ->
           console.log 'warn: no items in lineup that produces', consuming
         console.log("there are #{producers.length} instances of #{consuming}")
         producers.each (_i, el) ->
-          console.log("promise: ", el, el.promise)
           deps.push(el.promise)
-      console.log("waiting for:", deps)
       waitFor = Promise.all(deps)
     waitFor
       .then ->
-        console.log("getting promise for", name)
         bindPromise = pluginBind($item, item)
         if not bindPromise or typeof(bindPromise.then) == 'function'
           bindPromise = Promise.resolve(bindPromise)
         # This is where the "bind results" promise for the current item is stored
         $item[0].promise = bindPromise
-        console.log("promise bound for", name)
       .then ->
         # If the plugin has the needed callback, subscribe to server side events
         # for the current page

--- a/lib/plugin.coffee
+++ b/lib/plugin.coffee
@@ -1,5 +1,6 @@
 # The plugin module manages the dynamic retrieval of plugin
 # javascript including additional scripts that may be requested.
+forward = require './forward'
 
 module.exports = plugin = {}
 
@@ -93,6 +94,10 @@ bind = (name, pluginBind) ->
           bindPromise = Promise.resolve(bindPromise)
         $item[0].promise = bindPromise
         console.log("promise bound for", name)
+      .then ->
+        if window.plugins[name].processServerEvent
+          console.log 'listening for server events', $item, item
+          forward.init $item, item, window.plugins[name].processServerEvent
       # After we bind, notify everyone that depends on us to reload
       .then ->
         produces = plugin.produces($item)

--- a/lib/plugins.coffee
+++ b/lib/plugins.coffee
@@ -1,11 +1,12 @@
 # This module preloads the plugins directory with a few
 # plugins that we can't live without. They will be
 # browserified along with the rest of the core javascript.
+plugin = require './plugin'
 
 window.plugins =
-  reference: require './reference'
-  factory: require './factory'
-  paragraph: require './paragraph'
-  image: require './image'
-  future: require './future'
-  importer: require './importer'
+  reference: plugin.wrap('reference', require './reference')
+  factory: plugin.wrap('factory', require './factory')
+  paragraph: plugin.wrap('paragraph', require './paragraph')
+  image: plugin.wrap('image', require './image')
+  future: plugin.wrap('future', require './future')
+  importer: plugin.wrap('importer', require './importer')

--- a/lib/refresh.coffee
+++ b/lib/refresh.coffee
@@ -77,7 +77,6 @@ handleDrop = (evt, ui, originalIndex, originalOrder) ->
       $('.shadow-copy').remove()
       $item.empty()
       plugin.renderFrom originalIndex-1
-      #plugin.do $item.empty(), $item.data("item"), (->), originalIndex-1
       pageHandler.put $destinationPage, {id: item.id, type: 'move', order: order}
     return
   copying = sourceIsGhost or evt.shiftKey
@@ -97,7 +96,6 @@ handleDrop = (evt, ui, originalIndex, originalOrder) ->
   $('.shadow-copy').remove()
   $item.empty()
   plugin.renderFrom originalIndex - 1
-  #plugin.do $item.empty(), item, (->), originalIndex-1
 
 changeMouseCursor = (e, ui) ->
   $sourcePage = ui.item.data('pageElement')

--- a/lib/refresh.coffee
+++ b/lib/refresh.coffee
@@ -321,6 +321,8 @@ renderPageIntoPageElement = (pageObject, $page) ->
         [$item_, item_, itemElem_] = enclosed
         plugin.getPlugin item_.type, (plugin) ->
           plugin.bind $item_, item_
+  .then ->
+    return $page
 
   if $('.editEnable').is(':visible')
     pageObject.seqActions (each, done) ->
@@ -415,7 +417,9 @@ cycle = ($page) ->
       key = link.parents('.page').data('key')
       create = lineup.atKey(key)?.getCreate()
       pageObject = newFuturePage(title)
-      buildPage( pageObject, $page ).addClass('ghost')
+      buildPage( pageObject, $page )
+        .then ($page) ->
+          $page.addClass('ghost')
         .then(resolve)
 
 

--- a/lib/refresh.coffee
+++ b/lib/refresh.coffee
@@ -305,12 +305,16 @@ renderPageIntoPageElement = (pageObject, $page) ->
   emitHeader $header, $page, pageObject
   emitTimestamp $header, $page, pageObject
 
+  # Emits can be done in parallel. We perform them sequentially here.
   emitp = pageObject.seqItems (item, done) ->
       $item = $ """<div class="item #{item.type}" data-id="#{item.id}">"""
       $story.append $item
       plugin.emit $item, item, {done}
   .then ->
     return $page
+  # Binds must be called sequentially in order to store the promises used to order bind operations.
+  # Note: The bind promises used here are for ordering "bind creation".
+  # The ordering of "bind results" is done within the plugin.bind wrapper.
   bindp = emitp.then ->
     $page.find('.item').each (_i, itemElem) ->
       console.log(itemElem)

--- a/lib/refresh.coffee
+++ b/lib/refresh.coffee
@@ -128,8 +128,9 @@ initDragging = ($page) ->
   originalIndex = null
   dragCancelled = null
   cancelDrag = (e) ->
-    dragCancelled = true
-    $story.sortable('cancel') if e.which == 27
+    if e.which == 27
+      dragCancelled = true
+      $story.sortable('cancel')
   $story.sortable(options)
     .on 'sortstart', (e, ui) ->
       $item = ui.item
@@ -151,6 +152,7 @@ initDragging = ($page) ->
     .on 'sortstop', (e, ui) ->
       $('body').css('cursor', origCursor).off('keydown', cancelDrag)
       handleDrop(e, ui, originalIndex, originalOrder) unless dragCancelled
+      $('.shadow-copy').remove()
 
 getPageObject = ($journal) ->
   $page = $($journal).parents('.page:first')

--- a/lib/refresh.coffee
+++ b/lib/refresh.coffee
@@ -53,7 +53,7 @@ equals = (a, b) -> a and b and a.get(0) == b.get(0)
 getStoryItemOrder = ($story) ->
   $story.children().map((_, value) -> $(value).attr('data-id')).get()
 
-handleDrop = (evt, ui, originalOrder) ->
+handleDrop = (evt, ui, originalIndex, originalOrder) ->
   $item = ui.item
 
   item = getItem($item)
@@ -74,6 +74,7 @@ handleDrop = (evt, ui, originalOrder) ->
   if moveWithinPage
     order = getStoryItemOrder($item.parents('.story:first'))
     if not _.isEqual(order, originalOrder)
+      plugin.do $item.empty(), $item.data("item"), (->), originalIndex
       pageHandler.put $destinationPage, {id: item.id, type: 'move', order: order}
     return
   copying = sourceIsGhost or evt.shiftKey
@@ -90,6 +91,7 @@ handleDrop = (evt, ui, originalOrder) ->
   item = aliasItem $destinationPage, $item, item
   pageHandler.put $destinationPage,
                   {id: item.id, type: 'add', item, after: before?.id}
+  plugin.do $item.empty(), item, (->), originalIndex
 
 changeMouseCursor = (e, ui) ->
   $sourcePage = ui.item.data('pageElement')
@@ -119,19 +121,22 @@ initDragging = ($page) ->
     delay: 150
   $story = $page.find('.story')
   originalOrder = null
+  originalIndex = null
   dragCancelled = null
   cancelDrag = (e) ->
     dragCancelled = true
     $story.sortable('cancel') if e.which == 27
   $story.sortable(options)
     .on 'sortstart', (e, ui) ->
+      $item = ui.item
       originalOrder = getStoryItemOrder($story)
+      originalIndex = $('.item').index($item)
       dragCancelled = false
       $('body').on('keydown', cancelDrag)
       # Create a copy that we control since sortable removes theirs too early.
       # Insert after the placeholder to prevent adding history when item not moved.
       # Clear out the styling they add. Updates to jquery ui can affect this.
-      ui.item.clone().insertAfter(ui.placeholder).hide().addClass("shadow-copy")
+      $item.clone().insertAfter(ui.placeholder).hide().addClass("shadow-copy")
         .css(
           width: ''
           height: ''
@@ -141,7 +146,7 @@ initDragging = ($page) ->
     .on 'sort', changeMouseCursor
     .on 'sortstop', (e, ui) ->
       $('body').css('cursor', origCursor).off('keydown', cancelDrag)
-      handleDrop(e, ui, originalOrder) unless dragCancelled
+      handleDrop(e, ui, originalIndex, originalOrder) unless dragCancelled
       $('.shadow-copy').remove()
 
 getPageObject = ($journal) ->
@@ -303,7 +308,17 @@ renderPageIntoPageElement = (pageObject, $page) ->
   pageObject.seqItems (item, done) ->
     $item = $ """<div class="item #{item.type}" data-id="#{item.id}">"""
     $story.append $item
-    plugin.do $item, item, done
+    plugin.emit $item, item, {done}
+  .then ->
+    $page.find('.item').each (_i, itemElem) ->
+      $item = $(itemElem)
+      item = $item.data('item')
+      try
+        throw [$item, item, itemElem]
+      catch enclosed
+        [$item_, item_, itemElem_] = enclosed
+        plugin.getPlugin item_.type, (plugin) ->
+          plugin.bind $item_, item_
 
   if $('.editEnable').is(':visible')
     pageObject.seqActions (each, done) ->

--- a/lib/refresh.coffee
+++ b/lib/refresh.coffee
@@ -311,6 +311,8 @@ renderPageIntoPageElement = (pageObject, $page) ->
     plugin.emit $item, item, {done}
   .then ->
     $page.find('.item').each (_i, itemElem) ->
+      console.log(itemElem)
+    $page.find('.item').each (_i, itemElem) ->
       $item = $(itemElem)
       item = $item.data('item')
       try
@@ -396,33 +398,35 @@ newFuturePage = (title, create) ->
       'create': create
   pageObject
 
-cycle = ->
-  $page = $(this)
+cycle = ($page) ->
+  return new Promise (resolve, _reject) ->
 
-  [slug, rev] = $page.attr('id').split('_rev')
-  pageInformation = {
-    slug: slug
-    rev: rev
-    site: $page.data('site')
-  }
+    [slug, rev] = $page.attr('id').split('_rev')
+    pageInformation = {
+      slug: slug
+      rev: rev
+      site: $page.data('site')
+    }
 
-  whenNotGotten = ->
-    link = $("""a.internal[href="/#{slug}.html"]:last""")
-    title = link.text() or slug
-    key = link.parents('.page').data('key')
-    create = lineup.atKey(key)?.getCreate()
-    pageObject = newFuturePage(title)
-    buildPage( pageObject, $page ).addClass('ghost')
+    whenNotGotten = ->
+      link = $("""a.internal[href="/#{slug}.html"]:last""")
+      title = link.text() or slug
+      key = link.parents('.page').data('key')
+      create = lineup.atKey(key)?.getCreate()
+      pageObject = newFuturePage(title)
+      buildPage( pageObject, $page ).addClass('ghost')
+      resolve()
 
 
-  whenGotten = (pageObject) ->
-    buildPage( pageObject, $page )
-    for site in pageObject.getNeighbors(location.host)
-      neighborhood.registerNeighbor site
+    whenGotten = (pageObject) ->
+      buildPage( pageObject, $page )
+      for site in pageObject.getNeighbors(location.host)
+        neighborhood.registerNeighbor site
+      resolve()
 
-  pageHandler.get
-    whenGotten: whenGotten
-    whenNotGotten: whenNotGotten
-    pageInformation: pageInformation
+    pageHandler.get
+      whenGotten: whenGotten
+      whenNotGotten: whenNotGotten
+      pageInformation: pageInformation
 
 module.exports = {cycle, emitTwins, buildPage, rebuildPage, newFuturePage}

--- a/lib/refresh.coffee
+++ b/lib/refresh.coffee
@@ -74,7 +74,7 @@ handleDrop = (evt, ui, originalIndex, originalOrder) ->
   if moveWithinPage
     order = getStoryItemOrder($item.parents('.story:first'))
     if not _.isEqual(order, originalOrder)
-      plugin.do $item.empty(), $item.data("item"), (->), originalIndex
+      plugin.do $item.empty(), $item.data("item"), (->), originalIndex-1
       pageHandler.put $destinationPage, {id: item.id, type: 'move', order: order}
     return
   copying = sourceIsGhost or evt.shiftKey
@@ -91,7 +91,7 @@ handleDrop = (evt, ui, originalIndex, originalOrder) ->
   item = aliasItem $destinationPage, $item, item
   pageHandler.put $destinationPage,
                   {id: item.id, type: 'add', item, after: before?.id}
-  plugin.do $item.empty(), item, (->), originalIndex
+  plugin.do $item.empty(), item, (->), originalIndex-1
 
 changeMouseCursor = (e, ui) ->
   $sourcePage = ui.item.data('pageElement')

--- a/lib/refresh.coffee
+++ b/lib/refresh.coffee
@@ -319,7 +319,6 @@ renderPageIntoPageElement = (pageObject, $page) ->
   bindp = emitp.then ->
     index = $(".page").index($page[0])
     itemIndex = $('.item').index($($('.page')[index]).find('.item'))
-    console.log('binding for page', itemIndex, $('.page')[index])
     plugin.renderFrom itemIndex
 
   if $('.editEnable').is(':visible')

--- a/lib/target.coffee
+++ b/lib/target.coffee
@@ -8,7 +8,7 @@ targeting = false
 item = null
 itemElem = null
 action = null
-consuming = null
+consumed = null
 
 
 
@@ -30,9 +30,9 @@ startTargeting = (e) ->
     if id = item || action
       $("[data-id=#{id}]").addClass('target')
     if itemElem
-      consuming = itemElem.consuming
-      if consuming
-        consuming.forEach (i) -> itemFor(i).addClass('consuming')
+      consumed = itemElem.consuming
+      if consumed
+        consumed.forEach (i) -> itemFor(i).addClass('consumed')
 
 
 
@@ -40,7 +40,7 @@ stopTargeting = (e) ->
   targeting = e.shiftKey
   unless targeting
     $('.item, .action').removeClass 'target'
-    $('.item').removeClass 'consuming'
+    $('.item').removeClass 'consumed'
 
 pageFor = (pageKey) ->
   $page = $('.page').filter((_i, page) => $(page).data('key') == pageKey)

--- a/lib/target.coffee
+++ b/lib/target.coffee
@@ -7,6 +7,7 @@
 targeting = false
 item = null
 action = null
+consuming = null
 
 
 
@@ -35,6 +36,20 @@ stopTargeting = (e) ->
   unless targeting
     $('.item, .action').removeClass 'target'
 
+pageFor = (pageKey) ->
+  $page = $('.page').filter((_i, page) => $(page).data('key') == pageKey)
+  return null if $page.length == 0
+  console.log('warning: more than one page found for', key, $page) if $page.length > 1
+  return $page
+
+itemFor = (pageItem) ->
+  [pageKey, item] = pageItem.split('/')
+  $page = pageFor(pageKey)
+  return null if !$page
+  $item = $page.find(".item[data-id=#{item}]")
+  return null if $item.length == 0
+  console.log('warning: more than one item found for', pageItem, $item) if $item.length > 1
+  return $item
 
 enterItem = (e) ->
   item = ($item = $(this)).attr('data-id')
@@ -43,10 +58,15 @@ enterItem = (e) ->
     key = ($page = $(this).parents('.page:first')).data('key')
     place = $item.offset().top
     $('.page').trigger('align-item', {key, id:item, place})
+  consuming = $item[0].consuming
+  if consuming
+    consuming.forEach (i) -> itemFor(i).addClass('consuming')
+
 
 leaveItem = (e) ->
   if targeting
     $('.item, .action').removeClass('target')
+  $('.item').removeClass('consuming')
   item = null
 
 

--- a/lib/target.coffee
+++ b/lib/target.coffee
@@ -65,15 +65,15 @@ enterItem = (e) ->
     key = ($page = $(this).parents('.page:first')).data('key')
     place = $item.offset().top
     $('.page').trigger('align-item', {key, id:item, place})
-    consuming = itemElem.consuming
-    if consuming
-      consuming.forEach (i) -> itemFor(i).addClass('consuming')
+    consumed = itemElem.consuming
+    if consumed
+      consumed.forEach (i) -> itemFor(i).addClass('consumed')
 
 
 leaveItem = (e) ->
   if targeting
     $('.item, .action').removeClass('target')
-    $('.item').removeClass('consuming')
+    $('.item').removeClass('consumed')
   item = null
   itemElem = null
 

--- a/lib/target.coffee
+++ b/lib/target.coffee
@@ -6,6 +6,7 @@
 
 targeting = false
 item = null
+itemElem = null
 action = null
 consuming = null
 
@@ -23,18 +24,23 @@ bind = ->
     .delegate '.page', 'align-item', alignItem
 
 
-
 startTargeting = (e) ->
   targeting = e.shiftKey
   if targeting
     if id = item || action
       $("[data-id=#{id}]").addClass('target')
+    if itemElem
+      consuming = itemElem.consuming
+      if consuming
+        consuming.forEach (i) -> itemFor(i).addClass('consuming')
+
 
 
 stopTargeting = (e) ->
   targeting = e.shiftKey
   unless targeting
     $('.item, .action').removeClass 'target'
+    $('.item').removeClass 'consuming'
 
 pageFor = (pageKey) ->
   $page = $('.page').filter((_i, page) => $(page).data('key') == pageKey)
@@ -43,31 +49,33 @@ pageFor = (pageKey) ->
   return $page
 
 itemFor = (pageItem) ->
-  [pageKey, item] = pageItem.split('/')
+  [pageKey, _item] = pageItem.split('/')
   $page = pageFor(pageKey)
   return null if !$page
-  $item = $page.find(".item[data-id=#{item}]")
+  $item = $page.find(".item[data-id=#{_item}]")
   return null if $item.length == 0
   console.log('warning: more than one item found for', pageItem, $item) if $item.length > 1
   return $item
 
 enterItem = (e) ->
   item = ($item = $(this)).attr('data-id')
+  itemElem = $item[0]
   if targeting
     $("[data-id=#{item}]").addClass('target')
     key = ($page = $(this).parents('.page:first')).data('key')
     place = $item.offset().top
     $('.page').trigger('align-item', {key, id:item, place})
-  consuming = $item[0].consuming
-  if consuming
-    consuming.forEach (i) -> itemFor(i).addClass('consuming')
+    consuming = itemElem.consuming
+    if consuming
+      consuming.forEach (i) -> itemFor(i).addClass('consuming')
 
 
 leaveItem = (e) ->
   if targeting
     $('.item, .action').removeClass('target')
-  $('.item').removeClass('consuming')
+    $('.item').removeClass('consuming')
   item = null
+  itemElem = null
 
 
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   ],
   "dependencies": {
     "async": "^2.6.0",
+    "grunt-contrib-uglify-es": "^3.3.0",
     "localforage": "^1.7.3",
     "underscore": "^1.8.3"
   },
@@ -42,7 +43,7 @@
     "grunt-babel": "^8.0.0",
     "grunt-browserify": "^5.2.0",
     "grunt-contrib-clean": "^2.0.0",
-    "grunt-contrib-uglify": "^4.0.0",
+    "grunt-contrib-uglify": "^3.3.0",
     "grunt-contrib-watch": "^1.0.0",
     "grunt-git-authors": "^3.2.0",
     "grunt-mocha-test": "^0.13.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   ],
   "dependencies": {
     "async": "^2.6.0",
-    "grunt-contrib-uglify-es": "^3.3.0",
     "localforage": "^1.7.3",
     "underscore": "^1.8.3"
   },
@@ -43,7 +42,7 @@
     "grunt-babel": "^8.0.0",
     "grunt-browserify": "^5.2.0",
     "grunt-contrib-clean": "^2.0.0",
-    "grunt-contrib-uglify": "^3.3.0",
+    "grunt-contrib-uglify-es": "^3.3.0",
     "grunt-contrib-watch": "^1.0.0",
     "grunt-git-authors": "^3.2.0",
     "grunt-mocha-test": "^0.13.2",


### PR DESCRIPTION
This PR makes a lot of changes.
* On initial page load plugin emits are done in parallel, but binds are done serially.
* Holding shift when hovering over items that consume other plugins will put an orange highlight around the consumed items (this requires plugin authors to add a `.consumed` attribute to their dom elements).
* Handle updating plugins that consume other plugins whenever a notable event occurs which includes:
  1. When an item is added
  1. When an item is removed
  1. When a page is opened
  1. When a page is removed
  1. When an item moves in the lineup
  1. When a page moved in the lineup
  1. When an item changes type
* Removes .js files from the `.gitignore` as there is now a javascript file in lib.
* Switches from uglify to uglify-es as the javascript file uses ES6 syntax.
* Fixes a bug that was preventing shift id highlighting from working when hovering over items with a gray background. (To take advantage of this, authors of such plugins need to add the `.output-item` class to the div of the item itself and remove any inner div with a manually set background color).
* Adds a socket io listener for all items of plugins that export a `processServerEvent` function. This function should take two arguments: the slugItem that produced the event and an event properties object. The properties in the object are plugin specific.
* There's a bunch of changes made to support the above items which required things like recording and passing previous item indexes, adding promises to certain functions, etc. I can provide more information if you have any questions about specific changes.

Log output cleanup is the primary work remaining on this. I'm opening the PR in the meantime to collect feedback.