### PR TITLE
Only cancel drag if escape is pressed.

### DIFF
--- a/lib/refresh.coffee
+++ b/lib/refresh.coffee
@@ -121,8 +121,9 @@ initDragging = ($page) ->
   originalOrder = null
   dragCancelled = null
   cancelDrag = (e) ->
-    dragCancelled = true
-    $story.sortable('cancel') if e.which == 27
+    if e.which == 27
+      dragCancelled = true
+      $story.sortable('cancel')
   $story.sortable(options)
     .on 'sortstart', (e, ui) ->
       originalOrder = getStoryItemOrder($story)


### PR DESCRIPTION
When code was added to allow item drag operations to be cancelled by pressing escape, it inadvertently broke the ability to copy items between pages.

This PR properly guards the setting of the `dragCancelled` flag so it only happens when escape is pressed.