### PR TITLE
Prevent page from being dropped on a journal

### DIFF
--- a/client/style/style.css
+++ b/client/style/style.css
@@ -162,6 +162,10 @@ footer {
   padding: 1px;
 }
 
+.journal.ui-draggable {
+  width: 420px;
+}
+
 .action.fork {
   color: black; }
 

--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -119,7 +119,7 @@ $ ->
     return false
 
   $('.main')
-    .sortable({handle: '.page-handle', cursor: 'grabbing'})
+    .sortable({handle: '.page-handle', cursor: 'grabbing', cancel: 'journal'})
       .on 'sortstart', (evt, ui) ->
         return if not ui.item.hasClass('page')
         noScroll = true

--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -119,7 +119,7 @@ $ ->
     return false
 
   $('.main')
-    .sortable({handle: '.page-handle', cursor: 'grabbing', cancel: 'journal'})
+    .sortable({handle: '.page-handle', cursor: 'grabbing'})
       .on 'sortstart', (evt, ui) ->
         return if not ui.item.hasClass('page')
         noScroll = true

--- a/lib/refresh.coffee
+++ b/lib/refresh.coffee
@@ -163,6 +163,7 @@ initMerging = ($page) ->
   $journal.droppable
     hoverClass: "ui-state-hover"
     drop: handleMerging
+    accept: '.journal'
 
 initAddButton = ($page) ->
   $page.find(".add-factory").on("click", (evt) ->


### PR DESCRIPTION
When reordering pages, it is sometimes possible to get the page to drop onto the journal of an adjacent page. The easiest way to reproduce this is to scroll down so a large journal is visible and then drag another page across the page with the large journal. The large journal will get a small outline when it is the drop target. If you drop the page at this point, the page freezes (example screenshot below).

![image](https://user-images.githubusercontent.com/306384/68870218-64e51680-06af-11ea-8165-6767af364809.png)

This is the error that appear in the JavaScript console.
```
client.max.js:2714 Uncaught TypeError: Cannot read property 'getRawPage' of undefined
    at Object.merge (client.max.js:2714)
    at HTMLDivElement.j (client.max.js:3630)
    at e.<computed>.<computed>._trigger (jquery-ui.min.js:6)
    at e.<computed>.<computed>._drop (jquery-ui.min.js:7)
    at e.<computed>.<computed>._drop (jquery-ui.min.js:6)
    at e.<computed>.<computed>.<anonymous> (jquery-ui.min.js:7)
    at Function.each (jquery-2.2.4.min.js:2)
    at Object.drop (jquery-ui.min.js:7)
    at e.<computed>.<computed>._mouseStop (jquery-ui.min.js:8)
    at e.<computed>.<computed>._mouseStop (jquery-ui.min.js:6)
```

This is prevented by configuring the journal's droppable to only accept other journals (this is done using the `accept` property of the droppable).
https://api.jqueryui.com/droppable/#option-accept

Another change is the addition of a style to constrain the width of the dragged journal so it doesn't flatten to a single row. This both looks nicer and is easier to manipulate. Obligatory screenshoots showing the effects of the style change below.

Before:
![image](https://user-images.githubusercontent.com/306384/68954271-8c53e600-0778-11ea-86b1-6dde6b8fad06.png)

After (ignore the yellow highlights - artifact of keys pressed to trigger the screenshot):
![image](https://user-images.githubusercontent.com/306384/68954245-7ba37000-0778-11ea-80b2-0accaa4012f2.png)
