### PR TITLE
Highlight items when their bind is blocked

### DIFF
--- a/client/style/style.css
+++ b/client/style/style.css
@@ -249,6 +249,9 @@ footer {
 .consumed {
   outline: solid 2px orange !important; }
 
+.highlight {
+  outline: solid 2px red; }
+
 .report p,
 .factory p,
 .data p,

--- a/lib/plugin.coffee
+++ b/lib/plugin.coffee
@@ -90,6 +90,7 @@ bind = (name, pluginBind) ->
     # Wait for all items in the lineup that produce what we consume
     # before calling our bind method.
     if consumes
+      $item[0].consuming = []
       deps = []
       consumes.forEach (consuming) ->
         producers = $(".item:lt(#{index})").filter(consuming)
@@ -99,6 +100,9 @@ bind = (name, pluginBind) ->
           console.log 'warn: no items in lineup that produces', consuming
         console.log("there are #{producers.length} instances of #{consuming}")
         producers.each (_i, el) ->
+          page_key = $(el).parents('.page').data('key')
+          item_id = $(el).attr('data-id')
+          $item[0].consuming.push("#{page_key}/#{item_id}")
           deps.push(el.promise)
       waitFor = Promise.all(deps)
     waitFor

--- a/lib/plugin.coffee
+++ b/lib/plugin.coffee
@@ -76,6 +76,12 @@ plugin.renderFrom = (notifIndex) ->
     bindNextItem($items.toArray())
   return promise
 
+emit = (pluginEmit) ->
+  fn = ($item, item) ->
+    $item.addClass('emit')
+    pluginEmit($item, item)
+  fn
+
 bind = (name, pluginBind) ->
   fn = ($item, item, oldIndex) ->
     index = $('.item').index($item)
@@ -97,6 +103,7 @@ bind = (name, pluginBind) ->
       waitFor = Promise.all(deps)
     waitFor
       .then ->
+        $item.removeClass('emit')
         bindPromise = pluginBind($item, item)
         if not bindPromise or typeof(bindPromise.then) == 'function'
           bindPromise = Promise.resolve(bindPromise)
@@ -113,6 +120,7 @@ bind = (name, pluginBind) ->
   return fn
 
 plugin.wrap = (name, p) ->
+  p.emit = emit(p.emit)
   p.bind = bind(name, p.bind)
   return p
 

--- a/lib/target.coffee
+++ b/lib/target.coffee
@@ -27,6 +27,7 @@ bind = ->
 startTargeting = (e) ->
   targeting = e.shiftKey
   if targeting
+    $('.emit').addClass('highlight')
     if id = item || action
       $("[data-id=#{id}]").addClass('target')
     if itemElem
@@ -39,6 +40,7 @@ startTargeting = (e) ->
 stopTargeting = (e) ->
   targeting = e.shiftKey
   unless targeting
+    $('.emit').removeClass('highlight')
     $('.item, .action').removeClass 'target'
     $('.item').removeClass 'consumed'
 


### PR DESCRIPTION
This PR reduces the requirements on plugin authors while also making the system easier to debug.

Prior to these changes, plugin authors had to remember to put a `consuming` property on their items as part of their bind. This was a manual, error prone process.

After this change, the bind wrapper in plugin takes care of this for them, but there is a slight difference in behavior.

The old behavior only tagged an item as consumed after it was consumed. The new behavior tags an item as consumed the moment something else is waiting on it. Without this change, it isn't possible to highlight what is blocking the bind of the items highlighted in red. With this change, shift hovering over an item in red will highlight in orange the items being consumed. At least one of those highlighted in orange will be the thing blocking the bind.

Here's a screenshot taken by reintroducing the lack of resolve on error defect in the datalog plugin.
![image](https://user-images.githubusercontent.com/306384/69064339-e05a0700-09d2-11ea-9825-5f9a7eb94ec6.png)

Shift hovering over either of the tail items will highlight all datalogs that are up and to the left of the hovered tail.
