### PR TITLE
Fix pressing enter to create new editors and clean up event handlers

### DIFF
--- a/lib/editor.coffee
+++ b/lib/editor.coffee
@@ -142,7 +142,6 @@ spawnEditor = ($page, $before, type, text) ->
     .data('item', item)
     .data('pageElement', $page)
   $before.after $item
-  plugin.do $item, item
   before = itemz.getItem $before
   textEditor $item, item, {after: before?.id}
 

--- a/lib/plugin.coffee
+++ b/lib/plugin.coffee
@@ -51,6 +51,7 @@ plugin.renderFrom = (notifIndex) ->
     item = $item.data('item')
     promise = promise.then ->
       return new Promise (resolve, reject) ->
+        $item.off()
         plugin.emit $item.empty(), item, () ->
           resolve()
     emitNextItem(itemElems)


### PR DESCRIPTION
When pressing enter in an editor, a new editor usually opens. With the most recent changes, this breaks.

This PR removes what appears to be an unnecessary call to `plugin.do`. That call is asynchronous and rerenders the lineup which stomps on the editor that is created right after the call.

It also calls `.off()` before rendering an item. This cleans up any event handlers previously attached to the item itself.