### PR TITLE
Clear previous 'consuming' list during bind

### DIFF
--- a/lib/plugin.coffee
+++ b/lib/plugin.coffee
@@ -93,7 +93,6 @@ bind = (name, pluginBind) ->
     # Wait for all items in the lineup that produce what we consume
     # before calling our bind method.
     if consumes
-      $item[0].consuming = []
       deps = []
       consumes.forEach (consuming) ->
         producers = $(".item:lt(#{index})").filter(consuming)

--- a/lib/plugin.coffee
+++ b/lib/plugin.coffee
@@ -85,6 +85,8 @@ emit = (pluginEmit) ->
 
 bind = (name, pluginBind) ->
   fn = ($item, item, oldIndex) ->
+    # Clear out any list of consumed items.
+    $item[0].consuming = []
     index = $('.item').index($item)
     consumes = window.plugins[name].consumes
     waitFor = Promise.resolve()


### PR DESCRIPTION
This is an odd defect.

![image](https://user-images.githubusercontent.com/306384/69435758-05ad8480-0cf5-11ea-8053-1471d987a08c.png)

When changing item types, the list of consumed items isn't cleared if the new item type doesn't consume anything. This makes it possible to make a `paragraph` look like it is consuming a `diag`. You do this by putting two diags next to each other and then changing the type of the second one to a paragraph.