### PR TITLE
Fix error preventing ghost on new pages

### DIFF
--- a/lib/refresh.coffee
+++ b/lib/refresh.coffee
@@ -316,12 +316,12 @@ renderPageIntoPageElement = (pageObject, $page) ->
       $story.append $item
       $item.data('item', item)
       done()
-  .then ->
-    return $page
   promise = promise.then ->
     index = $(".page").index($page[0])
     itemIndex = $('.item').index($($('.page')[index]).find('.item'))
     plugin.renderFrom itemIndex
+  .then ->
+    return $page
 
   if $('.editEnable').is(':visible')
     pageObject.seqActions (each, done) ->


### PR DESCRIPTION
This is a regression introduced when I reworked the set of promises returned when a page is built. New pages no longer have the ghost style applied to them.

![image](https://user-images.githubusercontent.com/306384/70062343-b2f88600-159a-11ea-8cb9-ace60ea69bd5.png)

This is error that appears in the console:
> client.max.js:4390 Uncaught (in promise) TypeError: Cannot read property 'addClass' of undefined
>    at client.max.js:4390

After the change, new pages again have the ghost style applied.

![image](https://user-images.githubusercontent.com/306384/70062514-023eb680-159b-11ea-805e-970b31e6f161.png)
