### PR TITLE
Fix issues with drag and drop.

### DIFF
--- a/lib/refresh.coffee
+++ b/lib/refresh.coffee
@@ -58,7 +58,7 @@ handleDrop = (evt, ui, originalIndex, originalOrder) ->
 
   item = getItem($item)
   $sourcePage = $item.data('pageElement')
-  sourceIsGhost = $sourcePage.hasClass('ghost')
+  sourceIsReadOnly = $sourcePage.hasClass('ghost') || $sourcePage.hasClass('remote')
 
   $destinationPage = $item.parents('.page:first')
   destinationIsGhost = $destinationPage.hasClass('ghost')
@@ -76,10 +76,12 @@ handleDrop = (evt, ui, originalIndex, originalOrder) ->
     if not _.isEqual(order, originalOrder)
       $('.shadow-copy').remove()
       $item.empty()
-      plugin.renderFrom originalIndex-1
+      index = $(".item").index($item)
+      index = originalIndex if originalIndex < index
+      plugin.renderFrom index
       pageHandler.put $destinationPage, {id: item.id, type: 'move', order: order}
     return
-  copying = sourceIsGhost or evt.shiftKey
+  copying = sourceIsReadOnly or evt.shiftKey
   if copying
     # If making a copy, update the temp clone so it becomes a true copy.
     $('.shadow-copy').removeClass('shadow-copy')
@@ -95,17 +97,20 @@ handleDrop = (evt, ui, originalIndex, originalOrder) ->
                   {id: item.id, type: 'add', item, after: before?.id}
   $('.shadow-copy').remove()
   $item.empty()
-  plugin.renderFrom originalIndex - 1
+  $before.after($item)
+  index = $(".item").index($item)
+  index = originalIndex if originalIndex < index
+  plugin.renderFrom index
 
 changeMouseCursor = (e, ui) ->
   $sourcePage = ui.item.data('pageElement')
-  sourceIsGhost = $sourcePage.hasClass('ghost')
+  sourceIsReadOnly = $sourcePage.hasClass('ghost') || $sourcePage.hasClass('remote')
   $destinationPage = ui.placeholder.parents('.page:first')
   destinationIsGhost = $destinationPage.hasClass('ghost')
   moveWithinPage = equals($sourcePage, $destinationPage)
   moveBetweenDuplicatePages = not moveWithinPage and \
     $sourcePage.attr('id') == $destinationPage.attr('id')
-  copying = sourceIsGhost or (e.shiftKey and not moveWithinPage)
+  copying = sourceIsReadOnly or (e.shiftKey and not moveWithinPage)
   if destinationIsGhost or moveBetweenDuplicatePages
     $('body').css('cursor', 'no-drop')
     $('.shadow-copy').hide()


### PR DESCRIPTION
Treat remote pages as read-only when dragging. You cannot move items within them and dragging 

Prior to this change remote items could be modified which would result in the remote page being forked.

Render the lineup starting at the earlier of the original location or the new location.

When copying or moving an item, the rendering was broken if the copy or move was to a position more than one spot before the original location.