### PR TITLE
decode urls based on image sufix

### DIFF
--- a/lib/drop.coffee
+++ b/lib/drop.coffee
@@ -24,6 +24,12 @@ isPage = (url) ->
     return item
   null
 
+isImage = (url) ->
+  parsedURL = nurl.parse(url, true, true)
+  if parsedURL.pathname.match(/\.(jpg|jpeg|png|svg)$/)
+    return url
+  null
+
 isVideo = (url) ->
   parsedURL = nurl.parse(url, true, true)
   # check if video dragged from search (Google)
@@ -68,6 +74,9 @@ dispatch = (handlers) ->
       if video = isVideo url
         if (handle = handlers.video)?
           return stop handle video
+      if image = isImage url
+        if (handle = handlers.image)?
+          return stop handle image
       punt = {url}
     if file = isFile event
       if (handle = handlers.file)?

--- a/lib/drop.coffee
+++ b/lib/drop.coffee
@@ -26,7 +26,7 @@ isPage = (url) ->
 
 isImage = (url) ->
   parsedURL = nurl.parse(url, true, true)
-  if parsedURL.pathname.match(/\.(jpg|jpeg|png|svg)$/)
+  if parsedURL.pathname.match(/\.(jpg|jpeg|png|svg)$/i)
     return url
   null
 

--- a/lib/factory.coffee
+++ b/lib/factory.coffee
@@ -229,8 +229,8 @@ resizeImage = (dataURL) ->
   cW = undefined
   cH = undefined
   # target size
-  tW = 800
-  tH = 512
+  tW = 500
+  tH = 300
   # image quality
   imageQuality = 0.5
 

--- a/lib/factory.coffee
+++ b/lib/factory.coffee
@@ -104,6 +104,12 @@ bind = ($item, item) ->
     item.text = "#{video.text}\n(double-click to edit caption)\n"
     syncEditAction()
 
+  addRemoteImage = (url) ->
+    item.type = 'image'
+    item.url = url
+    item.caption ||= "Remote image"
+    syncEditAction()
+
   readFile = (file) ->
     if file?
       [majorType, minorType] = file.type.split("/")
@@ -150,6 +156,7 @@ bind = ($item, item) ->
     page: addReference
     file: readFile
     video: addVideo
+    image: addRemoteImage
     punt: punt
 
 # from http://www.bennadel.com/blog/1504-Ask-Ben-Parsing-CSV-Strings-With-Javascript-Exec-Regular-Expression-Command.htm

--- a/lib/factory.coffee
+++ b/lib/factory.coffee
@@ -235,7 +235,6 @@ resizeImage = (dataURL) ->
   imageQuality = 0.5
 
   smallEnough = (img) ->
-    console.log 'smallEnough', img.width, '<=', tw, img.width <= tW, img.height, '<=', tH,  img.height <= tH
     img.width <= tW or img.height <= tH
 
   new Promise (resolve) ->
@@ -245,7 +244,6 @@ resizeImage = (dataURL) ->
   .then () ->
     cW = src.naturalWidth
     cH = src.naturalHeight
-    console.log 'naturalSize', cW, cH
   .then () ->
     # determine size for first squeeze
     return if smallEnough src
@@ -285,18 +283,13 @@ resizeImage = (dataURL) ->
         if smallEnough tmp
           return resolve dataURL  
         canvas = document.createElement('canvas')
-        
-        cW /= 2
-        cH /= 2
-        console.log 'drawImage', cW, cH
-
         canvas.width = cW
         canvas.height = cH
-        console.log 'canvas', canvas.width, canvas.height
         context = canvas.getContext('2d')
         context.drawImage tmp, 0, 0, cW, cH
-        console.log 'context', context.width, context.height
         dataURL = canvas.toDataURL('image/jpeg', imageQuality)
+        cW /= 2
+        cH /= 2
         tmp.src = dataURL
   .then ->
     return dataURL

--- a/lib/factory.coffee
+++ b/lib/factory.coffee
@@ -106,12 +106,12 @@ bind = ($item, item) ->
 
   addRemoteImage = (url) ->
     # give some feedback, in case this is going to take a while...
-    document.body.style.cursor = 'progress'
+    document.documentElement.style.cursor = 'wait'
     fetchRemoteImage(url)
       .then (dataURL) ->
         resizeImage dataURL
       .then (resizedImageURL) ->
-        document.body.style.cursor = 'default'
+        document.documentElement.style.cursor = 'default'
         item.type = 'image'
         item.url = resizedImageURL
         item.source = url

--- a/lib/factory.coffee
+++ b/lib/factory.coffee
@@ -235,6 +235,7 @@ resizeImage = (dataURL) ->
   imageQuality = 0.5
 
   smallEnough = (img) ->
+    console.log 'smallEnough', img.width, '<=', tw, img.width <= tW, img.height, '<=', tH,  img.height <= tH
     img.width <= tW or img.height <= tH
 
   new Promise (resolve) ->
@@ -244,6 +245,7 @@ resizeImage = (dataURL) ->
   .then () ->
     cW = src.naturalWidth
     cH = src.naturalHeight
+    console.log 'naturalSize', cW, cH
   .then () ->
     # determine size for first squeeze
     return if smallEnough src
@@ -251,7 +253,7 @@ resizeImage = (dataURL) ->
     oH = cH
     fW = cW.toString(2).length - tW.toString(2).length + 1
     fH = cH.toString(2).length - tH.toString(2).length + 1
-
+    console.log 'f', fW, fH, fW<=fH
     if fW <= fH
       cW = tW * fW
       cH = oH * (cW / oW)
@@ -269,11 +271,14 @@ resizeImage = (dataURL) ->
         
         cW /= 2
         cH /= 2
+        console.log 'drawImage', cW, cH
 
         canvas.width = cW
         canvas.height = cH
+        console.log 'canvas', canvas.width, canvas.height
         context = canvas.getContext('2d')
         context.drawImage tmp, 0, 0, cW, cH
+        console.log 'context', context.width, context.height
         dataURL = canvas.toDataURL('image/jpeg', imageQuality)
         tmp.src = dataURL
   .then ->

--- a/lib/factory.coffee
+++ b/lib/factory.coffee
@@ -105,10 +105,13 @@ bind = ($item, item) ->
     syncEditAction()
 
   addRemoteImage = (url) ->
+    # give some feedback, in case this is going to take a while...
+    document.body.style.cursor = 'progress'
     fetchRemoteImage(url)
       .then (dataURL) ->
         resizeImage dataURL
       .then (resizedImageURL) ->
+        document.body.style.cursor = 'default'
         item.type = 'image'
         item.url = resizedImageURL
         item.source = url

--- a/lib/factory.coffee
+++ b/lib/factory.coffee
@@ -248,32 +248,12 @@ resizeImage = (dataURL) ->
     # determine size for first squeeze
     return if smallEnough src
 
-    f = if cW / cH > tW / tH then cH / tH else cW / tW
+    oversize = Math.max 1, Math.min cW/tW, cH/tH
+    iterations = Math.floor Math.log2 oversize
+    prescale = oversize / 2**iterations
 
-    fW = Math.round(cW / f)
-    fH = Math.round(cH / f)
-
-    squeezes = 0
-
-    if fW = tW
-      x = tW
-      y = cW
-    else
-      x = tH
-      y = cH
-    
-    while x < y
-      x *= 2
-      squeezes += 1
-
-    cW = fW
-    cH = fH
-
-    x = 1
-    while x < squeezes
-      cW *= 2
-      cH *= 2
-      x++
+    cW = Math.round(cW / prescale)
+    cH = Math.round(cH / prescale)
 
   .then () ->
     new Promise (resolve) ->

--- a/lib/factory.coffee
+++ b/lib/factory.coffee
@@ -249,17 +249,34 @@ resizeImage = (dataURL) ->
   .then () ->
     # determine size for first squeeze
     return if smallEnough src
-    oW = cW
-    oH = cH
-    fW = cW.toString(2).length - tW.toString(2).length + 1
-    fH = cH.toString(2).length - tH.toString(2).length + 1
-    console.log 'f', fW, fH, fW<=fH
-    if fW <= fH
-      cW = tW * fW
-      cH = oH * (cW / oW)
+
+    f = if cW / cH > tW / tH then cH / tH else cW / tW
+
+    fW = Math.round(cW / f)
+    fH = Math.round(cH / f)
+
+    squeezes = 0
+
+    if fW = tW
+      x = tW
+      y = cW
     else
-      cH = tH * fH
-      cW = oW * (cH / oH)
+      x = tH
+      y = cH
+    
+    while x < y
+      x *= 2
+      squeezes += 1
+
+    cW = fW
+    cH = fH
+
+    x = 1
+    while x < squeezes
+      cW *= 2
+      cH *= 2
+      x++
+
   .then () ->
     new Promise (resolve) ->
       tmp = new Image

--- a/lib/factory.coffee
+++ b/lib/factory.coffee
@@ -216,7 +216,7 @@ fetchRemoteImage = (url) ->
     
 
 
-# from http://www.benknowscode.com/2014/01/resizing-images-in-browser-using-canvas.html
+# from https://web.archive.org/web/20140327091827/http://www.benknowscode.com/2014/01/resizing-images-in-browser-using-canvas.html
 # Patrick Oswald version from comment, coffeescript and further simplification for wiki
 
 resizeImage = (dataURL) ->

--- a/lib/image.coffee
+++ b/lib/image.coffee
@@ -7,11 +7,15 @@ editor = require './editor'
 resolve = require './resolve'
 
 ipfs = false
-gateway = "http://127.0.0.1:8080"
-$.ajax "#{gateway}/ipfs/Qmb1oS3TaS8vekxXqogoYsixe47sXcVxQ22kPWH8VSd7yQ",
-  timeout: 30000
-  success: (data) -> ipfs = data == "wiki\n"
-  complete: (xhr, status) -> console.log "ipfs gateway #{status}"
+ipfs_probed = false
+
+probe_ipfs = () ->
+  ipfs_probed = true
+  gateway = "http://127.0.0.1:8080"
+  $.ajax "#{gateway}/ipfs/Qmb1oS3TaS8vekxXqogoYsixe47sXcVxQ22kPWH8VSd7yQ",
+    timeout: 30000
+    success: (data) -> ipfs = data == "wiki\n"
+    complete: (xhr, status) -> console.log "ipfs gateway #{status}"
 
 emit = ($item, item) ->
   item.text ||= item.caption
@@ -21,10 +25,16 @@ bind = ($item, item) ->
   $item.dblclick ->
     editor.textEditor $item, item
 
+  if (item.ipfs and not ipfs_probed)
+    probe_ipfs()
+
   $item.find('img').dblclick (event) ->
     event.stopPropagation()
     url = if ipfs and item.ipfs?
       "#{gateway}/ipfs/#{item.ipfs}"
+    else if item.source?
+      # somehow test for continued existnace? Maybe register an error handler?
+      item.source
     else
       item.url
     dialog.open item.text, """<img style="width:100%" src="#{url}">"""

--- a/scripts/squeeze-logic.coffee
+++ b/scripts/squeeze-logic.coffee
@@ -1,0 +1,13 @@
+
+squeeze = (source) ->
+  target = {x:500, y:300}
+  oversize = Math.max 1, Math.min( source.x/target.x, source.y/target.y)
+  iterations = Math.floor Math.log2 oversize
+  prescale = oversize / 2 ** iterations
+  console.log source, oversize, '=', prescale, '* 2 ^', iterations
+
+tests = [210, 510, 1100, 2100, 5100, 11000]
+for x in tests
+  console.log ''
+  for y in tests
+    squeeze {x, y}

--- a/scripts/squeeze-test.js
+++ b/scripts/squeeze-test.js
@@ -1,0 +1,69 @@
+// Using testcheck to validate the algorithm used for squeezing an image.
+// usage: npm i testcheck; node script/squeeze-test.js
+
+const { check, gen, property } = require('testcheck')
+
+function resizeImage(startWidth, startHeight) {
+  var cW = startWidth
+  var cH = startHeight
+  var tW = 500
+  var tH = 300
+
+  const smallEnough = function smallEnough(width, height) {
+    return width <= tW || height <= tH
+  }
+
+  // determine size for first squeeze
+  const f = 
+    cW / cH > tW / tH
+       ? cH / tH
+       : cW / tW
+
+  // final size (we need to round as target number, as target size is not 2^n)
+  var fW = Math.round(cW / f)
+  var fH = Math.round(cH / f)
+
+  //console.log('target', fW, fH)
+  
+  var squeezes = 0
+  var x
+  var y
+  if (fW = tW) {
+    x = tW
+    y = cW
+  } else {
+    x = tH
+    y = cH
+  }
+  do {
+    x *= 2
+    squeezes += 1
+  } while (x < y)
+
+  // first squeeze will be to
+  cW = fW
+  cH = fH
+  for (let x = 1; x < squeezes; x++) {
+    cW *= 2
+    cH *= 2
+  }
+  //console.log('*first squeeze', startWidth, startHeight, cW, cH )
+
+  // and then squeeze until smallEnough, if not already smallEnough
+  if (!smallEnough(cW, cH)) {
+      do {
+        cH /= 2
+        cW /= 2
+      } while (!smallEnough(cW, cH))
+    }
+
+  //console.log(startWidth, startHeight, cW, cH) 
+
+  return ((cW = tW && cH >= tH) || (cH = tH && cW >= tW))
+}
+
+const result = check(property([gen.intWithin(450,4096), gen.intWithin(250,4096)], (x,y) => {
+  return resizeImage(x,y)
+}), {seed: 50, numTests: 1001})
+
+console.log(result)


### PR DESCRIPTION
Work in Progress

This should be enough to drag image urls to a factory and get an Image item that cites the remote resource. We've resisted this before because the remote image can disappear. This is a step forward toward more advanced image handling.

Aside: I couldn't demonstrate even this much in my development environment. I'd love to pair in order to get past this inability.

Some further work we'd like to explore:

- [x] fetch the image in some cors compatible way and validate that it is an image.
- [x] fetch the image and store a thumbnail in the image that won't go away
- [ ] fetch the image and save it in the image assets folder
- [x] bypass cors limitation by enriching Image items server side