### PR TITLE
Scripts for packaging

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "underscore": "^1.9.2"
   },
   "scripts": {
+    "build": "grunt build",
     "test": "grunt mochaTest"
   },
   "devDependencies": {

--- a/scripts/preview-package
+++ b/scripts/preview-package
@@ -1,0 +1,49 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\r\t'
+
+usage() {
+  cat <<EOF
+Usage: $(basename $0) SEGMENT [PREID]
+
+SEGMENT must be one of premajor, preminor, prepatch, or prerelease
+PREID is optional. Unless specified, it is computed from git branch
+
+Creates a node package tarball from the code in the current branch.
+It uses npm version and npm pack, but deliberately does NOT commit
+changes to git. We aim to enable wiki developers to install and test
+before submitting PRs.
+
+NOTE: modifies version in package.json and package-lock.json
+You probably don't want to check in those changes.
+
+EOF
+}
+
+main() {
+  readonly SEGMENT=${1-UNSPECIFIED}
+  if is-not-prerelease $SEGMENT; then
+    usage
+    exit 1
+  fi
+
+  readonly PREID=${2-$(convert-git-branch-to-semver-prerelease)}
+  npm version $SEGMENT --preid=$PREID --force --no-git-tag-version &>/dev/null
+  export PACKAGE=$(npm pack 2>/dev/null | tail -1)
+  echo $PACKAGE
+}
+
+is-not-prerelease() {
+  ! [[ " premajor preminor prepatch prerelease " =~ " $1 " ]]
+}
+
+convert-git-branch-to-semver-prerelease() {
+  # semver spec for pre-release: https://semver.org/#spec-item-9
+  # 1. remove any path-like prefixes
+  # 2. convert underscores to hyphens
+  # 3. strip all other invalid characters
+  local RAW_BRANCH=$(git branch --show-current)
+  basename $RAW_BRANCH | perl -pe 's/_/-/g;s/[^0-9A-Za-z-]//g'
+}
+
+main $@

--- a/scripts/scopify-package
+++ b/scripts/scopify-package
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -euo pipefail
+ITS=$'\n\r\t'
+
+readonly SCOPE="${1-MISSING}"
+
+usage() {
+  cat <<EOF
+Usage:
+  $(basename $0) SCOPE < package.original.json > package.json
+
+  both SCOPE and STDIN are required
+  SCOPE is expected to be the github username (or maybe orgname)
+  STDIN is expected to be a package.json
+
+EOF
+}
+
+main() {
+  # 1. set registry to github's
+  # 2. set the repo URL to the github fork
+  # 3. set the scope in the package name
+  jq ".publishConfig.registry=\"https://npm.pkg.github.com/\" \
+  |.repository.url=\"https://github.com/${SCOPE}/wiki-client\" \
+  |.name=\"@${SCOPE}/wiki-client\""
+}
+
+missing-scope() {
+  [ "${SCOPE}" = "MISSING" ]
+}
+
+missing-stdin() {
+  [ -t 0 ]
+}
+
+if missing-scope || missing-stdin; then
+  usage
+  exit 1
+else
+  main $@
+fi


### PR DESCRIPTION
These three changes seem generally useful and worth contributing now, ahead of the other explorations around GitHub actions and workflows.

`scripts/preview-package` generates a node package tarball with a speculative semver version. The motivated developer can copy the tarball to a web server and `npm install http://...` the tarball.

There are two other places I have experimented with this kind of workflow:
* the glitch wiki development experiment (and this in particular https://glitch.com/edit/#!/wiki-dev?path=build-wiki.sh)
* using a wiki assets folder as a package repo for local experiments

`scripts/scopify-package` was created specifically for use with GitHub package registry. This is promoted into a script so it can be debugged and tested outside of GitHub actions.

Last is a convenience to be able to run the build without having grunt installed globally.