### PR TITLE
Add Backlinks and resolve a siteAdapter issue

### DIFF
--- a/client/style/print.css
+++ b/client/style/print.css
@@ -47,6 +47,10 @@ A:link, A:visited {
 	font-weight: 500;
 }
 
+.backlinks {
+	display: none;
+}
+
 .journal {
 	display: none;
 }

--- a/client/style/style.css
+++ b/client/style/style.css
@@ -191,7 +191,7 @@ footer {
   font-size: 80%;
 }
 
-.backlinks h3 {
+.backlinks summary {
   margin-top: 5px;
   margin-left: 5px;
   margin-bottom: 3px;

--- a/client/style/style.css
+++ b/client/style/style.css
@@ -181,10 +181,35 @@ footer {
 .image .thumbnail {
   width: 100%; }
 
+.backlinks {
+  width: 420px;
+  margin-top: 2px;
+  clear: both;
+  background-color: #eeeeee;
+  padding: 1px;
+  color: grey;
+  font-size: 80%;
+}
+
+.backlinks h3 {
+  margin-top: 5px;
+  margin-left: 5px;
+  margin-bottom: 3px;
+}
+
+.backlinks div {
+  margin-left: 5px;
+  margin-right: 2px;
+}
+
+.backlinks a {
+  color: steelblue;
+}
+
 .journal {
   /*width: 420px;*/
   overflow-x: hidden;
-  margin-top: 2px;
+/*  margin-top: 2px; */
   clear: both;
   background-color: #eeeeee;
   overflow: auto;

--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -301,6 +301,7 @@ $ ->
   $('body').on 'new-neighbor-done', (e, neighbor) ->
     $('.page').each (index, element) ->
       refresh.emitTwins $(element)
+      # refresh backlinks??
 
   getPluginReference = (title) ->
     return new Promise((resolve, reject) ->

--- a/lib/neighborhood.coffee
+++ b/lib/neighborhood.coffee
@@ -247,7 +247,6 @@ neighborhood.backLinks = (slug) ->
             site: neighborSite
             itemId: sitemapData.links[slug]
             date: sitemapData.date
-  console.log '+++++ backlinks - finds', finds
   results = {}
 
   finds.forEach (find) ->
@@ -261,8 +260,6 @@ neighborhood.backLinks = (slug) ->
       site: find['site']
       date: find['date']
       itemId: find['itemId']
-  
-  console.log '+++++ backlinks - results', results
   results
     
   

--- a/lib/neighborhood.coffee
+++ b/lib/neighborhood.coffee
@@ -231,3 +231,38 @@ neighborhood.search = (searchQuery)->
   
   tally['msec'] = Date.now() - start
   { finds, tally }
+
+neighborhood.backLinks = (slug) ->
+
+  finds = []
+
+  for own neighborSite, neighborInfo of neighborhood.sites
+    if neighborInfo.sitemap
+      neighborInfo.sitemap.forEach (sitemapData, pageSlug) ->
+        if sitemapData.links?.includes(slug)
+          finds.push
+            slug: sitemapData.slug
+            title: sitemapData.title
+            site: neighborSite
+            date: sitemapData.date
+  console.log '+++++ backlinks - finds', finds
+  results = {}
+
+  finds.forEach (find) ->
+
+    slug = find['slug']
+    title = find['title']
+    site = find['site']
+    date = find['date']
+
+    results[slug] = results[slug] or {}
+    results[slug]['title'] = title
+    results[slug]['sites'] = results[slug]['sites'] or []
+    results[slug]['sites'].push
+      site: site
+      date: date
+  
+  console.log '+++++ backlinks - results', results
+  results
+    
+  

--- a/lib/neighborhood.coffee
+++ b/lib/neighborhood.coffee
@@ -239,11 +239,12 @@ neighborhood.backLinks = (slug) ->
   for own neighborSite, neighborInfo of neighborhood.sites
     if neighborInfo.sitemap
       neighborInfo.sitemap.forEach (sitemapData, pageSlug) ->
-        if sitemapData.links?.includes(slug)
+        if sitemapData.links? and Object.keys(sitemapData.links).length > 0 and Object.keys(sitemapData.links).includes(slug)
           finds.push
             slug: sitemapData.slug
             title: sitemapData.title
             site: neighborSite
+            itemId: sitemapData.links[slug]
             date: sitemapData.date
   console.log '+++++ backlinks - finds', finds
   results = {}
@@ -251,16 +252,14 @@ neighborhood.backLinks = (slug) ->
   finds.forEach (find) ->
 
     slug = find['slug']
-    title = find['title']
-    site = find['site']
-    date = find['date']
 
     results[slug] = results[slug] or {}
-    results[slug]['title'] = title
+    results[slug]['title'] = find['title']
     results[slug]['sites'] = results[slug]['sites'] or []
     results[slug]['sites'].push
-      site: site
-      date: date
+      site: find['site']
+      date: find['date']
+      itemId: find['itemId']
   
   console.log '+++++ backlinks - results', results
   results

--- a/lib/neighborhood.coffee
+++ b/lib/neighborhood.coffee
@@ -73,7 +73,8 @@ neighborhood.updateSitemap = (pageObject)->
   date = pageObject.getDate()
   title = pageObject.getTitle()
   synopsis = pageObject.getSynopsis()
-  entry = {slug, date, title, synopsis}
+  links = pageObject.getLinks()
+  entry = {slug, date, title, synopsis, links}
   sitemap = neighborInfo.sitemap
   index = sitemap.findIndex (slot) -> slot.slug == slug
   if index >= 0

--- a/lib/neighbors.coffee
+++ b/lib/neighbors.coffee
@@ -10,6 +10,8 @@ neighborhood = require './neighborhood'
 sites = null
 totalPages = 0
 
+hasLinks = (element) -> element.hasOwnProperty('links')
+
 
 flag = (site) ->
   # status class progression: .wait, .fetch, .fail or .done
@@ -33,7 +35,10 @@ bind = ->
     .on 'new-neighbor-done', (e, site) ->
       pageCount = sites[site].sitemap.length
       img = $(""".neighborhood .neighbor[data-site="#{site}"]""").find('img')
-      img.attr('title', "#{site}\n #{pageCount} pages")
+      if sites[site].sitemap.some(hasLinks)
+        img.attr('title', "#{site}\n #{pageCount} pages with 2-way links")
+      else
+        img.attr('title', "#{site}\n #{pageCount} pages")
       totalPages += pageCount
       $('.searchbox .pages').text "#{totalPages} pages"
     .delegate '.neighbor img', 'click', (e) ->

--- a/lib/page.coffee
+++ b/lib/page.coffee
@@ -111,6 +111,32 @@ newPage = (json, site) ->
   getSynopsis = ->
     synopsis page
 
+  getLinks = ->
+
+    extractPageLinks = (collaborativeLinks, currentItem, currentIndex, array) ->
+      # extract collaborative links 
+      # - this will need extending if we also extract the id of the item containing the link
+      try
+        linkRe = /\[\[([^\]]+)\]\]/g
+        match = undefined
+        while (match = linkRe.exec(currentItem.text)) != null
+          if not collaborativeLinks.has(asSlug(match[1]))
+            collaborativeLinks.set(asSlug(match[1]), currentItem.id)
+      catch err
+        console.log "*** Error extracting links from #{currentIndex} of #{JSON.stringify(array)}", err.message
+      collaborativeLinks
+
+    try
+      pageLinksMap = page.story.reduce( extractPageLinks, new Map())
+    catch err
+      console.log "+++ Extract links on #{page.slug} fails", err
+    if pageLinksMap.size > 0
+      pageLinks = Object.fromEntries(pageLinksMap)
+    else
+      pageLinks = {}
+    pageLinks
+
+
   addItem = (item) ->
     item = _.extend {}, {id: random.itemId()}, item
     page.story.push item
@@ -189,6 +215,6 @@ newPage = (json, site) ->
     isCreate = (action) -> action.type == 'create'
     page.journal.reverse().find(isCreate)
 
-  {getRawPage, getContext, isPlugin, isRemote, isLocal, isRecycler, getRemoteSite, getRemoteSiteDetails, getSlug, getNeighbors, getTitle, setTitle, getRevision, getDate, getTimestamp, getSynopsis, addItem, getItem, addParagraph, seqItems, seqActions, become, siteLineup, merge, apply, getCreate}
+  {getRawPage, getContext, isPlugin, isRemote, isLocal, isRecycler, getRemoteSite, getRemoteSiteDetails, getSlug, getNeighbors, getTitle, getLinks, setTitle, getRevision, getDate, getTimestamp, getSynopsis, addItem, getItem, addParagraph, seqItems, seqActions, become, siteLineup, merge, apply, getCreate}
 
 module.exports = {newPage, asSlug, asTitle, pageEmitter}

--- a/lib/refresh.coffee
+++ b/lib/refresh.coffee
@@ -256,22 +256,28 @@ emitBacklinks = ($backlinks, pageObject) ->
     
     for linkSlug, backlink of backlinks
       backlink.sites.sort (a,b) ->
-        a.site.date < b.site.date
-      flags = for i, site of backlink.sites
-        """
-          <img class="remote"
-               src="#{wiki.site(site.site).flag()}"
-               data-slug="#{linkSlug}"
-               data-site="#{site.site}"
-               data-id="#{site.itemId}"
-               title="#{site.site}\n#{wiki.util.formatElapsedTime site.date}">
-        """
+        (a.date || 0) < (b.date || 0)
+      flags = []
+      for site, i in backlink.sites
+        if i < 10
+          joint = if backlink.sites[i-1]?.date == site.date then "" else " "
+          flags.unshift joint
+          flags.unshift """
+            <img class="remote"
+                src="#{wiki.site(site.site).flag()}"
+                data-slug="#{linkSlug}"
+                data-site="#{site.site}"
+                data-id="#{site.itemId}"
+                title="#{site.site}\n#{wiki.util.formatElapsedTime site.date}">
+          """
+        else if i == 10
+          flags.unshift ' ⋯ '
       
       linkBack = resolve.resolveLinks("[[#{backlink.title}]]")
       links.push """
         <div style="clear: both;">
           <div style="float: left;">#{linkBack}</div>
-          <div style="text-align: right;"> #{flags.join " "} </div>
+          <div style="text-align: right;"> #{flags.join('')} </div>
         </div>
       """
 

--- a/lib/refresh.coffee
+++ b/lib/refresh.coffee
@@ -251,16 +251,13 @@ emitControls = ($journal) ->
 emitBacklinks = ($backlinks, pageObject) ->
   slug = pageObject.getSlug()
   backlinks = neighborhood.backLinks(slug)
-  console.log '+++++ Backlinks ===', backlinks
   if Object.keys(backlinks).length > 0
     links = []
     
     for linkSlug, backlink of backlinks
-      console.log "+++++ backlink -> ", linkSlug, backlink
       backlink.sites.sort (a,b) ->
         a.site.date < b.site.date
       flags = for i, site of backlink.sites
-        console.log '!!!!!!! in flags', site
         """
           <img class="remote"
                src="#{wiki.site(site.site).flag()}"
@@ -279,7 +276,6 @@ emitBacklinks = ($backlinks, pageObject) ->
       """
 
     if links
-      console.log '+++++ we have some links'
       $backlinks.append """
         <details>
           <summary>#{links.length} pages link here:</summary>

--- a/lib/refresh.coffee
+++ b/lib/refresh.coffee
@@ -266,6 +266,7 @@ emitBacklinks = ($backlinks, pageObject) ->
                src="#{wiki.site(site.site).flag()}"
                data-slug="#{linkSlug}"
                data-site="#{site.site}"
+               data-id="#{site.itemId}"
                title="#{site.site}\n#{wiki.util.formatElapsedTime site.date}">
         """
       
@@ -280,8 +281,10 @@ emitBacklinks = ($backlinks, pageObject) ->
     if links
       console.log '+++++ we have some links'
       $backlinks.append """
-        <h3>Linked from:</h3>
-        #{links.join "\n"}
+        <details>
+          <summary>#{links.length} pages link here:</summary>
+          #{links.join "\n"}
+        </details>
       """
 
 emitFooter = ($footer, pageObject) ->

--- a/lib/siteAdapter.coffee
+++ b/lib/siteAdapter.coffee
@@ -352,8 +352,10 @@ siteAdapter.site = (site) ->
                   done err, page
             else
               done null, data
+              Promise.resolve(data) unless callback
           error: (xhr, type, msg) ->
             done {msg, xhr}, null
+            Promise.reject(msg) unless callback
 
       if sitePrefix[site]?
         if sitePrefix[site] is ""
@@ -400,8 +402,10 @@ siteAdapter.site = (site) ->
                   done err, page
             else
               done null, data
+              Promise.resolve(data) unless callback
           error: (xhr, type, msg) ->
             done {msg, xhr}, null
+            Promise.reject(msg) unless callback
 
       if sitePrefix[site]?
         if sitePrefix[site] is ""

--- a/lib/siteAdapter.coffee
+++ b/lib/siteAdapter.coffee
@@ -102,12 +102,12 @@ findAdapter = (site, done) ->
     console.log "findAdapter: ", site, value
     if !value?
       findAdapterQ.push {site: site}, (prefix) ->
+        sitePrefix[site] = prefix
         routeStore.setItem(site, prefix).then (value) ->
           done prefix
         .catch (err) ->
           console.log "findAdapter setItem error: ", site, err
-          sitePrefix[site] = ""
-          done ""
+          done prefix
     else
       sitePrefix[site] = value
       done value

--- a/lib/target.coffee
+++ b/lib/target.coffee
@@ -22,6 +22,8 @@ bind = ->
     .delegate '.action', 'mouseenter', enterAction
     .delegate '.action', 'mouseleave', leaveAction
     .delegate '.page', 'align-item', alignItem
+    .delegate '.backlinks .remote', 'mouseenter', enterBacklink
+    .delegate '.backlinks .remote', 'mouseleave', leaveBacklink
 
 
 startTargeting = (e) ->
@@ -94,6 +96,20 @@ leaveAction = (e) ->
   action = null
 
 
+enterBacklink = (e) ->
+  item = ($item = $(this)).attr('data-id')
+  itemElem = $item[0]
+  if targeting
+    $("[data-id=#{item}]").addClass('target')
+    key = ($page = $(this).parents('.page:first')).data('key')
+    place = $item.offset().top
+    $('.page').trigger('align-item', {key, id: item, place})
+
+leaveBacklink = (e) ->
+  if targeting
+    $('.item, .action').removeClass('target')
+  item = null
+  itemElem = null
 
 alignItem = (e, align) ->
   $page = $(this)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wiki-client",
-  "version": "0.20.3",
+  "version": "0.20.4-experimental",
   "description": "Federated Wiki - Client-side Javascript",
   "keywords": [
     "wiki",


### PR DESCRIPTION
This PR adds backlinks to a wiki page. This relies on extra link information being in the sitemap, added by the changes in fed-wiki/wiki-server#161
Backlinks are added at the bottom of the wiki page, just above the journal if it is being shown, initially in a collapsed state:
![Screenshot 2020-12-31 at 17 18 44](https://user-images.githubusercontent.com/1552489/103419775-6c55d080-4b8c-11eb-9481-e2d766e8c58b.png)
This expands to show a collaborative link for the page linking, and flags for the sites the page with links was found on:
![Screenshot 2020-12-31 at 17 18 58](https://user-images.githubusercontent.com/1552489/103419851-aa52f480-4b8c-11eb-90f4-59b1d5cd7cd7.png)
Clicking on the collaborative link in the list behaves exactly as if the link was within the page. Click on the flag will open page from the wiki that flag is for. 

Holding shift and hovering over the flag will highlight, and try to align, the page item containing the link. Just like it does with page items and journal items already.

A bug was discovered in the siteAdapter, where if there was an error saving how to access a remote site it would incorrectly set the site inaccessible. This appears to happen when the adapter has been called more that once for a site. This has addressed by using the value we have, and is stored in memory, and just reporting that the issue with the persistent store.

Also in the siteAdapter, some promise returns are added that appear to have been missed when others were added a while ago.

The changes in this PR are intended for use along with the changes in fedwiki/wiki-server#161