### PR TITLE
collaborative links now prefer the title

### DIFF
--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -176,11 +176,12 @@ $ ->
       active.set this unless $(e.target).is("a")
 
     .delegate '.internal', 'click', (e) ->
-      name = $(e.target).data 'pageName'
+      $link = $(e.target)
+      title = $link.text() or $link.data 'pageName'
       # ensure that name is a string (using string interpolation)
-      name = "#{name}"
+      title = "#{title}"
       pageHandler.context = $(e.target).attr('title').split(' => ')
-      finishClick e, name
+      finishClick e, title
 
     .delegate 'img.remote', 'click', (e) ->
       # expand to handle click on temporary flag

--- a/lib/link.coffee
+++ b/lib/link.coffee
@@ -8,9 +8,9 @@ active = require './active'
 refresh = require './refresh'
 {asTitle, asSlug, pageEmitter} = require './page'
 
-createPage = (name, loc) ->
+createPage = (name, loc, title=null) ->
   site = loc if loc and loc isnt 'view'
-  title = asTitle(name)
+  title = asTitle(name) unless title
   $page = $ """
     <div class="page" id="#{name}" tabindex="-1">
       <div class="paper">
@@ -24,14 +24,14 @@ createPage = (name, loc) ->
   $page.data('site', site) if site
   $page
 
-showPage = (name, loc) ->
-  createPage(name, loc).appendTo('.main').each((_i, e) -> refresh.cycle($(e)))
+showPage = (name, loc, title=null) ->
+  createPage(name, loc, title).appendTo('.main').each((_i, e) -> refresh.cycle($(e)))
 
-doInternalLink = (name, $page, site=null) ->
-  name = asSlug(name)
+doInternalLink = (title, $page, site=null) ->
+  slug = asSlug(title)
   $($page).nextAll().remove() if $page?
   lineup.removeAllAfterKey $($page).data('key') if $page?
-  showPage(name,site)
+  showPage(slug, site, title)
   active.set($('.page').last())
 
 showResult = (pageObject, options={}) ->

--- a/lib/refresh.coffee
+++ b/lib/refresh.coffee
@@ -450,6 +450,7 @@ newFuturePage = (title, create) ->
 cycle = ($page) ->
   promise = new Promise (resolve, _reject) ->
     [slug, rev] = $page.attr('id').split('_rev')
+    title = $page.find('.header h1').text().trim()
     pageInformation = {
       slug: slug
       rev: rev
@@ -458,7 +459,7 @@ cycle = ($page) ->
 
     whenNotGotten = ->
       link = $("""a.internal[href="/#{slug}.html"]:last""")
-      title = link.text() or slug
+      title = title or link.text() or slug
       key = link.parents('.page').data('key')
       create = lineup.atKey(key)?.getCreate()
       pageObject = newFuturePage(title)


### PR DESCRIPTION
Prior to this change, doInternalLink() would receive a title or a slug, convert it to a slug, and call showPage() with the slug. refresh.cycle() would be invoked which resolved the slug back into a title. That particular flow would fail for clicks on the graphviz plugin.

This change lets the original title be passed through to createPage for the cases when we already know the intended title, like the graphviz case.