### PR TITLE
Assign cloned item to  when aliasing to prevent undesired ui changes

### DIFF
--- a/lib/refresh.coffee
+++ b/lib/refresh.coffee
@@ -35,6 +35,7 @@ getItem = ($item) ->
 
 aliasItem = ($page, $item, oldItem) ->
   item = $.extend {}, oldItem
+  $item.data('item', item);
   pageObject = lineup.atKey($page.data('key'))
   if pageObject.getItem(item.id)?
     item.alias ||= item.id


### PR DESCRIPTION
Steps to replicate:

1. Have two pages open next to each other
2. Create a new paragraph in the first column
3. shift-click-drag the paragraph to the second column (to copy)
4. double-click the original paragraph and change the text

What I expect to happen:

1. Only the text in the first column changes

What actually happens:

1. The text changes in both columns (only in UI, if I refresh the page it corrects itself)

Resolution:

1. In `refresh.coffee` function `aliasItem` we are already cloning `oldItem` as `item` (via `$.extend`)
2. Assign this cloned `item` to `$item` via the data method (`$item.data('item', item')`)