### PR TITLE
RFC: Adding a presave hook in editor focusoutHandler

### DIFF
--- a/lib/editor.coffee
+++ b/lib/editor.coffee
@@ -95,7 +95,9 @@ textEditor = ($item, item, option={}) ->
     $item.removeClass 'textEditing'
     $textarea.unbind()
     $page = $item.parents('.page:first')
-    if item[option.field||'text'] = $textarea.val()
+    presave = option.presave or (item, value) ->
+      return value
+    if item[option.field||'text'] = presave item, $textarea.val()
       # Remove output and source styling as type may have changed.
       $item.removeClass("output-item")
       $item.removeClass (_index, className) ->


### PR DESCRIPTION
I'm curious if there have been any conversations about providing hooks in the code to allow plugins to extend core functionality.  Here is an example of adding a "presave" hook to the editor.

I've created a plugin that would use this hook as a proof of concept.

https://github.com/andrewshell/wiki-plugin-metadata/blob/master/client/metadata.js#L26-L35

I'm sure there will need to be discussions before something like this gets merged. So I'm documenting the idea with working code.