### PR TITLE
likely change for drop-import of single page-json file

### DIFF
--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -86,7 +86,9 @@ $ ->
         resultPage.setTitle "Import from #{file.name}"
         if pages.title? && pages.story? && pages.journal?
           slug = asSlug pages.title
-          pages[slug] = pages
+          page = pages
+          pages = {}
+          pages[slug] = page
           resultPage.addParagraph """
             Import of one page
             (#{commas file.size} bytes)

--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -84,11 +84,20 @@ $ ->
         pages = JSON.parse result
         resultPage = newPage()
         resultPage.setTitle "Import from #{file.name}"
-        resultPage.addParagraph """
-          Import of #{Object.keys(pages).length} pages
-          (#{commas file.size} bytes)
-          from an export file dated #{file.lastModifiedDate}.
-        """
+        if pages.title? && pages.story? && pages.journal?
+          slug = asSlug pages.title
+          pages[slug] = pages
+          resultPage.addParagraph """
+            Import of one page
+            (#{commas file.size} bytes)
+            from a page-json file dated #{file.lastModifiedDate}.
+          """
+        else
+          resultPage.addParagraph """
+            Import of #{Object.keys(pages).length} pages
+            (#{commas file.size} bytes)
+            from an export file dated #{file.lastModifiedDate}.
+          """
         resultPage.addItem {type: 'importer', pages: pages}
         link.showResult resultPage
       reader.readAsText(file)


### PR DESCRIPTION
We have had a request for the ability to share a single wiki page with other federated wiki users. A suggested application what selectively sharing private pages via other file sharing such as email.

We note that the JSON link at the bottom of every page will respond favorably to the `Save Link As...` menu by writing a page-json page for any page visible to the current viewer, logged on or not.

This modification notices when a single page-json file has been dropped as if it were export json. We wrap the dropped page with another layer of object so that it falls into line with normal import. We also adjust the importer page synopsis to make it clear how the drop has been interpreted.