### PR TITLE
correctly count number of pages

### DIFF
--- a/lib/neighbors.coffee
+++ b/lib/neighbors.coffee
@@ -46,7 +46,7 @@ bind = ->
       catch error
         console.info '+++ sitemap not valid for ', site
         sites[site].sitemap = []
-      totalPages += pageCount 
+      totalPages = Object.values(neighborhood.sites).reduce ((sum, site) -> site.sitemap.length), 0
       $('.searchbox .pages').text "#{totalPages} pages"
     .delegate '.neighbor img', 'click', (e) ->
       # add handling refreshing neighbor that has failed


### PR DESCRIPTION
Pages count was getting increased incorrectly each time the sitemap got updated - adding the number of pages in the origin site each time.

This change corrects that, by summing the number of pages from the sitemaps for the sites in the neighbourhood.