### PR TITLE
update url on fork from history

### DIFF
--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -253,6 +253,8 @@ $ ->
         if $page.data('rev')?
           $page.find('.revision').remove()
         $page.removeClass 'ghost'
+        $page.attr('id', $page.attr('id').replace(/_rev\d+$/,''))
+        state.setUrl()
         pageHandler.put $page, action
 
     .delegate 'button.create', 'click', (e) ->

--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -255,6 +255,9 @@ $ ->
         $page.removeClass 'ghost'
         $page.attr('id', $page.attr('id').replace(/_rev\d+$/,''))
         state.setUrl()
+        for p,i in $('.page')
+          if $(p).data('key') != $page.data('key') and $(p).attr('id') == $page.attr('id') and $(p).attr('site') == $page.attr('site')
+            $(p).addClass('ghost')
         pageHandler.put $page, action
 
     .delegate 'button.create', 'click', (e) ->


### PR DESCRIPTION
First step in lineup reconciliation when forking from history.
Here we update the url to remove the _rev suffix from the page that is now the current version.