### PR TITLE
ignore any sites with sitemap request still inflight when counting pages

### DIFF
--- a/lib/neighbors.coffee
+++ b/lib/neighbors.coffee
@@ -46,7 +46,16 @@ bind = ->
       catch error
         console.info '+++ sitemap not valid for ', site
         sites[site].sitemap = []
-      totalPages = Object.values(neighborhood.sites).reduce ((sum, site) -> site.sitemap.length), 0
+      totalPages = Object.values(neighborhood.sites).reduce ((sum, site) -> 
+        try
+          if site.sitemapRequestInflight
+            return 0
+          else
+            return site.sitemap.length
+        catch error
+          console.log('failed in new neighbour done', site, error)
+          return 0
+        ), 0
       $('.searchbox .pages').text "#{totalPages} pages"
     .delegate '.neighbor img', 'click', (e) ->
       # add handling refreshing neighbor that has failed


### PR DESCRIPTION
The total number of pages gets recalculated triggered by the `new-neighbor-done` event. However, some neighbors might not be done yet so those will fail with a type error when trying to count the number of pages with `site.sitemap.length`.

In this change any site that are still in flight, `sitemapRequestInflight` is still `true`, are ignored. They will eventually get included as they complete and fire their own `new-neighbor-done` event.