### PR TITLE
remember to add number of pages to the running total

### DIFF
--- a/lib/neighbors.coffee
+++ b/lib/neighbors.coffee
@@ -49,12 +49,12 @@ bind = ->
       totalPages = Object.values(neighborhood.sites).reduce ((sum, site) -> 
         try
           if site.sitemapRequestInflight
-            return 0
+            return sum
           else
-            return site.sitemap.length
+            return sum + site.sitemap.length
         catch error
           console.log('failed in new neighbour done', site, error)
-          return 0
+          return sum
         ), 0
       $('.searchbox .pages').text "#{totalPages} pages"
     .delegate '.neighbor img', 'click', (e) ->


### PR DESCRIPTION
At some point I there was the change from `totalPages += pageCount` on each sitemap load, which if I remember correctly was inflating the number. To doing the count across all the sitemaps from fresh each time, using `reduce()`. For whatever reason that reduce never added the number of pages in each wiki into the running total. 😊 