### PR TITLE
add full internet toggle to footer

### DIFF
--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -368,6 +368,17 @@ $ ->
         refresh.rebuildPage pageObject, $page.empty()
   $('.editEnable').toggle() unless isAuthenticated
 
+  $("<span> full <span class=fullEnable>✔︎</span> &nbsp; </span>")
+    .css({"cursor":"pointer"})
+    .appendTo('footer')
+    .click ->
+      $('.fullEnable').toggle()
+      # $('.page').each ->
+      #   $page = $(this)
+      #   pageObject = lineup.atKey $page.data('key')
+      #   refresh.rebuildPage pageObject, $page.empty()
+  $('.fullEnable').toggle() unless window.location.protocol is 'http:'
+
   target.bind()
 
   $ ->


### PR DESCRIPTION
Our federation spans two protocols, http and https.

The full federation is only visible when the origin javascript comes from an http site. Some argue that a more restricted internet is preferable. We would argue that even when this is the case a user must be able to view the full internet if the attribution clause of the CC BY-SA 4.0 license is to be meaningful. This pull request elevates this decision to a check-off in the web page footer.

<img width="592" alt="Screen Shot 2022-11-26 at 12 35 04 PM" src="https://user-images.githubusercontent.com/12127/204108413-00380102-f62d-4cf7-8ffc-ee9a3806e5ec.png">

This implementation will sense the protocol in use and display a check mark accordingly.

We have not implemented the code that will change protocol but expect it will have a user experience similar to enabling or disabling wiki mode with the adjacent check-off.

We don't know if it is possible to dynamically detect what protocols are supported by a given server. Perhaps this will require a server configuration parameter. In any case we suggest when full internet is unavailable that clicking the full check-off should open an informative about-page explaining the potential violation of license terms.