### PR TITLE
give search results ghost a journal

### DIFF
--- a/lib/importer.coffee
+++ b/lib/importer.coffee
@@ -35,7 +35,7 @@ bind = ($item, item) ->
     slug = $(e.target).attr('href')
     $page = $(e.target).parents('.page') unless e.shiftKey
     pageObject = newPage(item.pages[slug])
-    link.showResult pageObject, {$page, rev:pageObject.getRevision()}
+    link.showResult pageObject, {$page}
     false
 
 module.exports = {emit, bind}

--- a/lib/search.coffee
+++ b/lib/search.coffee
@@ -156,9 +156,6 @@ createSearch = ({neighborhood})->
         "story": deepCopy(resultPage.story)
       },
       "date": Date.now()
-    },{
-      "type": "fork",
-      "date": Date.now()
     }]
     pageObject = newPage resultPage
     link.showResult pageObject

--- a/lib/search.coffee
+++ b/lib/search.coffee
@@ -14,6 +14,9 @@ page = require './page'
 escapeRegExp = (string) ->
   string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 
+deepCopy = (object) ->
+  JSON.parse JSON.stringify object
+
 # From reference.coffee
 emit = ($item, item) ->
   slug = item.slug
@@ -126,22 +129,39 @@ createSearch = ({neighborhood})->
       return
     $('.incremental-search').remove()
     tally = searchResults.tally
-    resultPage = newPage()
-    resultPage.setTitle "Search for '#{searchQuery}'"
-    resultPage.addParagraph """
+    resultPage = {}
+    resultPage.title = "Search for '#{searchQuery}'"
+    resultPage.story = []
+    resultPage.story.push({
+      'type': 'paragraph'
+      'id': random.itemId()
+      'text': """
         String '#{searchQuery}' found on #{tally.finds||'none'} of #{tally.pages||'no'} pages from #{tally.sites||'no'} sites.
         Text matched on #{tally.title||'no'} titles, #{tally.text||'no'} paragraphs, and #{tally.slug||'no'} slugs.
         Elapsed time #{tally.msec} milliseconds.
-    """
+    """ })
     for result in searchResults.finds
-      resultPage.addItem
+      resultPage.story.push({
         "type": "reference"
         "site": result.site
         "slug": result.page.slug
         "title": result.page.title
         "text": result.page.synopsis || ''
+      })
 
-    link.showResult resultPage
+    resultPage.journal = [{
+      "type": "create",
+      "item": {
+        "title": resultPage.title,
+        "story": deepCopy(resultPage.story)
+      },
+      "date": Date.now()
+    },{
+      "type": "fork",
+      "date": Date.now()
+    }]
+    pageObject = newPage resultPage
+    link.showResult pageObject
 
 
   {


### PR DESCRIPTION
adding a journal with a create actions to the search results allow a forked result page to be later removed.