### PR TITLE
sitemap refresh

### DIFF
--- a/lib/neighborhood.coffee
+++ b/lib/neighborhood.coffee
@@ -37,7 +37,7 @@ populateSiteInfoFor = (site,neighborInfo)->
     return ms
 
   refreshMap = (site, neighborInfo) ->
-    console.log('time to refresh map', site)
+    console.log('refreshing', site)
     neighborInfo.sitemapRequestInflight = true
     sitemapURL = wiki.site(site).getURL('system/sitemap.json')
 
@@ -45,9 +45,12 @@ populateSiteInfoFor = (site,neighborInfo)->
       .then (response) ->
         neighborInfo.sitemapRequestInflight = false
         if response.ok
+          lastModified = Date.parse(response.headers.get('last-modified'))
+          if isNaN(lastModified)
+            lastModified = 0
           return {
             sitemap: await response.json(),
-            lastModified: Date.parse(response.headers.get('last-modified'))
+            lastModified: lastModified
             }
         transition site, 'fetch', 'fail'
         wiki.site(site).refresh () ->

--- a/lib/neighborhood.coffee
+++ b/lib/neighborhood.coffee
@@ -64,7 +64,7 @@ populateSiteInfoFor = (site,neighborInfo)->
           $('body').trigger 'new-neighbor-done', site
           # update the index as well
           refreshIndex(site, neighborInfo)
-        updateDelay = boundedDelay(Date.now() - lastModified)
+        updateDelay = boundedDelay((Date.now() - lastModified) / 4 )
         neighborInfo.nextCheck = Date.now() + updateDelay
         console.log('delay for ', site, (updateDelay / 60000))
         transition site, 'fetch', 'done'

--- a/lib/neighborhood.coffee
+++ b/lib/neighborhood.coffee
@@ -11,6 +11,9 @@ neighborhood.sites = {}
 nextAvailableFetch = 0
 nextFetchInterval = 500
 
+delay = (ms) ->
+  return new Promise((resolve) -> setTimeout(resolve, ms))
+
 populateSiteInfoFor = (site,neighborInfo)->
   return if neighborInfo.sitemapRequestInflight
   neighborInfo.sitemapRequestInflight = true
@@ -21,19 +24,57 @@ populateSiteInfoFor = (site,neighborInfo)->
       .removeClass(from)
       .addClass(to)
 
-  fetchMap = ->
-    transition site, 'wait', 'fetch'
-    wiki.site(site).get 'system/sitemap.json', (err, data) ->
-      neighborInfo.sitemapRequestInflight = false
-      if !err
-        neighborInfo.sitemap = data
-        transition site, 'fetch', 'done'
-        $('body').trigger 'new-neighbor-done', site
-      else
+  boundedDelay = (ms) ->
+    minDelay = 60000      # 1 minute
+    maxDelay = 86400000   # 1 day
+
+    if ms > maxDelay
+      return maxDelay
+
+    if ms < minDelay
+      return minDelay
+    
+    return ms
+
+  refreshMap = (site, neighborInfo) ->
+    console.log('time to refresh map', site)
+    neighborInfo.sitemapRequestInflight = true
+    sitemapURL = wiki.site(site).getURL('system/sitemap.json')
+
+    fetch(sitemapURL)
+      .then (response) ->
+        neighborInfo.sitemapRequestInflight = false
+        if response.ok
+          return {
+            sitemap: await response.json(),
+            lastModified: Date.parse(response.headers.get('last-modified'))
+            }
         transition site, 'fetch', 'fail'
         wiki.site(site).refresh () ->
           # empty function
+        throw new Error('Unable to fetch sitemap')
+      .then (processed) ->
+        { sitemap, lastModified } = processed
+        if lastModified > neighborInfo.lastModified
+          neighborInfo.sitemap = sitemap
+          neighborInfo.lastModified = lastModified
+          $('body').trigger 'new-neighbor-done', site
+          # update the index as well
+          refreshIndex(site, neighborInfo)
+        updateDelay = boundedDelay(Date.now() - lastModified)
+        console.log('delay for ', site, (updateDelay / 60000))
+        transition site, 'fetch', 'done'
+        delay updateDelay
+          .then () ->
+            transition site, 'done', 'fetch'
+            refreshMap site, neighborInfo
+        return
+      .catch (e) ->
+        console.log(site, e)
+        transition site, 'fetch', 'fail'
+        return
 
+  refreshIndex = (site, neighborInfo) ->
     # we use `wiki.site(site).getIndex` as we want the serialized index as a string.
     wiki.site(site).getIndex 'system/site-index.json', (err, data) ->
       if !err
@@ -46,6 +87,12 @@ populateSiteInfoFor = (site,neighborInfo)->
           console.log 'error loading index - not a valid index', site
       else
         console.log 'error loading index', site, err
+
+
+  fetchMap = ->
+    transition site, 'wait', 'fetch'
+    neighborInfo.lastModified = 0
+    refreshMap site, neighborInfo
 
   now = Date.now()
   if now > nextAvailableFetch

--- a/lib/neighborhood.coffee
+++ b/lib/neighborhood.coffee
@@ -62,6 +62,7 @@ populateSiteInfoFor = (site,neighborInfo)->
           # update the index as well
           refreshIndex(site, neighborInfo)
         updateDelay = boundedDelay(Date.now() - lastModified)
+        neighborInfo.nextCheck = Date.now() + updateDelay
         console.log('delay for ', site, (updateDelay / 60000))
         transition site, 'fetch', 'done'
         delay updateDelay

--- a/lib/neighborhood.coffee
+++ b/lib/neighborhood.coffee
@@ -26,7 +26,7 @@ populateSiteInfoFor = (site,neighborInfo)->
 
   boundedDelay = (ms) ->
     minDelay = 60000      # 1 minute
-    maxDelay = 86400000   # 1 day
+    maxDelay = 43200000   # 12 hours
 
     if ms > maxDelay
       return maxDelay
@@ -64,7 +64,7 @@ populateSiteInfoFor = (site,neighborInfo)->
           $('body').trigger 'new-neighbor-done', site
           # update the index as well
           refreshIndex(site, neighborInfo)
-        updateDelay = boundedDelay((Date.now() - lastModified) / 4 )
+        updateDelay = boundedDelay(Math.floor((Date.now() - lastModified) / 4 ))
         neighborInfo.nextCheck = Date.now() + updateDelay
         console.log('delay for ', site, (updateDelay / 60000))
         transition site, 'fetch', 'done'

--- a/lib/neighbors.coffee
+++ b/lib/neighbors.coffee
@@ -16,7 +16,6 @@ hasLinks = (element) -> element.hasOwnProperty('links')
 
 flag = (site) ->
   # status class progression: .wait, .fetch, .fail or .done
-  console.log 'neighbor - flag'
   """
     <span class="neighbor" data-site="#{site}">
       <div class="wait">
@@ -29,7 +28,6 @@ inject = (neighborhood) ->
   sites = neighborhood.sites
 
 formatNeighborTitle = (site) ->
-  console.log('formatTitle', { site, sites, neighborhood })
   title = ''
   title += "#{site}\n"
   try
@@ -70,7 +68,6 @@ bind = ->
         ), 0
       $('.searchbox .pages').text "#{totalPages} pages"
     .on 'mouseenter', '.neighbor', (e) ->
-      console.log('mouse enter (e)' , e)
       $neighbor = $(e.currentTarget)
       site = $neighbor.data().site
       $neighbor.find('img:first').attr('title', formatNeighborTitle(site))

--- a/lib/util.coffee
+++ b/lib/util.coffee
@@ -50,7 +50,6 @@ util.formatElapsedTime = (msSinceEpoch) ->
 
 util.formatDelay = (msSinceEpoch) ->
   msecs = (msSinceEpoch - Date.now())
-  console.log('util.formatDelay', msSinceEpoch, msecs)
   return "in #{Math.floor msecs} milliseconds" if (secs = msecs/1000) < 2
   return "in #{Math.floor secs} seconds" if (mins = secs/60) < 2
   return "in #{Math.floor mins} minutes" if (hrs = mins/60) < 2

--- a/lib/util.coffee
+++ b/lib/util.coffee
@@ -4,7 +4,6 @@
 
 module.exports = util = {}
 
-
 # for chart plug-in
 util.formatTime = (time) ->
   d = new Date (if time > 10000000000 then time else time*1000)
@@ -49,3 +48,10 @@ util.formatElapsedTime = (msSinceEpoch) ->
   return "#{Math.floor months} months ago" if (years = days/365) < 2
   return "#{Math.floor years} years ago"
 
+util.formatDelay = (msSinceEpoch) ->
+  msecs = (msSinceEpoch - Date.now())
+  console.log('util.formatDelay', msSinceEpoch, msecs)
+  return "in #{Math.floor msecs} milliseconds" if (secs = msecs/1000) < 2
+  return "in #{Math.floor secs} seconds" if (mins = secs/60) < 2
+  return "in #{Math.floor mins} minutes" if (hrs = mins/60) < 2
+  return "in #{Math.floor hrs} hours"


### PR DESCRIPTION
Add a periodic refresh of sitemaps, if there have been any remote changes.

Add some extra information to the hover information on the flags in the neighbourhood bar.
![Screenshot 2022-12-20 at 18 54 02](https://user-images.githubusercontent.com/1552489/208744710-c5699e82-b070-4b20-b946-84da99e3f216.png)

The refresh interval depends on how long ago the sitemap was updated. The initial thought was that they should be checked as far in the future as they were last updated in the past, but limited to be no more than a day. This is probably too infrequent, so will most likely be reduced.