### PR TITLE
Use github actions to run tests on PRs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        # Releases https://github.com/nodejs/release#release-schedule
+        node-version:
+          - 18.x # LTS
+          - 19.x # Current
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+      - run: npm run build --if-present
+      - run: npm test


### PR DESCRIPTION
`npm test` runs against the latest 2 node versions when PRs are opened.

While I do have a habit of running these locally, it's really nice to be able to see a passing test suite before jumping into code reviews.

Example test run:
https://github.com/heymatthew/wiki-client/actions/runs/3907659277