### PR TITLE
Update to minisearch 6

### DIFF
--- a/lib/neighborhood.coffee
+++ b/lib/neighborhood.coffee
@@ -163,7 +163,7 @@ extractPageText = (pageText, currentItem) ->
           # really need to extract text from the markdown, but for now just remove link brackets, urls...
           pageText += ' ' + currentItem.text.replace /\[{2}|\[(?:[\S]+)|\]{1,2}|\\n/g, ' '
         when 'html'
-          pageText += ' ' + currentItem.text.replace /<[^>]*>/g, ''
+          pageText += ' ' + currentItem.text.replace /<[^\>]*>?/g, ''
         else
           if currentItem.text?
             for line in currentItem.text.split /\r\n?|\n/

--- a/lib/neighborhood.coffee
+++ b/lib/neighborhood.coffee
@@ -173,49 +173,36 @@ extractPageText = (pageText, currentItem) ->
   pageText
 
 
-neighborhood.updateIndex = (pageObject, originalStory) ->
+neighborhood.updateIndex = (pageObject) ->
   console.log "updating #{pageObject.getSlug()} in index"
   site = location.host
   return unless neighborInfo = neighborhood.sites[site]
-
-  originalText = originalStory.reduce( extractPageText, '')
 
   slug = pageObject.getSlug()
   title = pageObject.getTitle()
   rawStory = pageObject.getRawPage().story
   newText = rawStory.reduce( extractPageText, '')
 
-  # try remove original page from index
-  try
-    neighborInfo.siteIndex.remove {
+  if neighborInfo.siteIndex.has(slug)
+    neighborInfo.siteIndex.replace {
       'id': slug
       'title': title
-      'content': originalText
+      'content': newText
     }
-  catch err
-    # swallow error, if the page was not in index
-    console.log "removing #{slug} from index failed", err unless err.message.includes('not in the index')
-
-  neighborInfo.siteIndex.add {
-    'id': slug
-    'title': title
-    'content': newText
-  }
+  else
+    neighborInfo.siteIndex.add {
+      'id': slug
+      'title': title
+      'content': newText
+    }
 
 neighborhood.deleteFromIndex = (pageObject) ->
   site = location.host
   return unless neighborInfo = neighborhood.sites[site]
 
   slug = pageObject.getSlug()
-  title = pageObject.getTitle()
-  rawStory = pageObject.getRawPage().story
-  pageText = rawStory.reduce(extractPageText, '')
   try
-    neighborInfo.siteIndex.remove {
-      'id': slug
-      'title': title
-      'content': pageText
-    }
+    neighborInfo.siteIndex.discard(slug)
   catch err
     # swallow error, if the page was not in index
     console.log "removing #{slug} from index failed", err unless err.message.includes('not in the index')

--- a/lib/pageHandler.coffee
+++ b/lib/pageHandler.coffee
@@ -127,29 +127,22 @@ pushToServer = ($page, pagePutInfo, action) ->
   if action.type == 'fork'
     bundle.item = deepCopy pageObject.getRawPage()
 
-  # we need the original page so we can update the index
-  wiki.origin.get "#{pagePutInfo.slug}.json", (err, originalPage) ->
+  wiki.origin.put pagePutInfo.slug, bundle, (err) ->
     if err
-      originalStory = []
+      action.error = { type: err.type, msg: err.msg, response: err.xhr.responseText}
+      pushToLocal $page, pagePutInfo, action
     else
-      originalStory = originalPage.story or []
-
-    wiki.origin.put pagePutInfo.slug, bundle, (err) ->
-      if err
-        action.error = { type: err.type, msg: err.msg, response: err.xhr.responseText}
-        pushToLocal $page, pagePutInfo, action
-      else
-        pageObject.apply action if pageObject?.apply
-        neighborhood.updateSitemap pageObject
-        neighborhood.updateIndex pageObject, originalStory
-        addToJournal $page.find('.journal'), action
-        if action.type == 'fork'
-          wiki.local.delete $page.attr('id')
-        if action.type != 'fork' and action.fork
-          # implicit fork, probably only affects image plugin
-          if action.item.type is 'image'
-            index = $page.find('.item').index($page.find('#' + action.item.id).context)
-            wiki.renderFrom index
+      pageObject.apply action if pageObject?.apply
+      neighborhood.updateSitemap pageObject
+      neighborhood.updateIndex pageObject
+      addToJournal $page.find('.journal'), action
+      if action.type == 'fork'
+        wiki.local.delete $page.attr('id')
+      if action.type != 'fork' and action.fork
+        # implicit fork, probably only affects image plugin
+        if action.item.type is 'image'
+          index = $page.find('.item').index($page.find('#' + action.item.id).context)
+          wiki.renderFrom index
 
 
 pageHandler.put = ($page, action) ->

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,9 +30,9 @@
         "grunt-git-authors": "^3.2.0",
         "grunt-mocha-test": "^0.13.2",
         "grunt-retire": "^1.0.3",
-        "minisearch": "^5.0.0",
-        "mocha": "^9.2.1",
-        "sinon": "^11.1.2"
+        "minisearch": "^6.0.0",
+        "mocha": "^10.2.0",
+        "sinon": "^15.0.1"
       },
       "engines": {
         "node": ">=8.x"
@@ -442,9 +442,9 @@
       }
     },
     "node_modules/@babel/core/node_modules/caniuse-lite": {
-      "version": "1.0.30001444",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001444.tgz",
-      "integrity": "sha512-ecER9xgJQVMqcrxThKptsW0pPxSae8R2RB87LNa+ivW9ppNWRHEplXcDzkCOP4LYWGj8hunXLqaiC41iBATNyg==",
+      "version": "1.0.30001445",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001445.tgz",
+      "integrity": "sha512-8sdQIdMztYmzfTMO6KfLny878Ln9c2M0fc7EH60IjlP4Dc4PiCy7K2Vl3ITmWgOyPgVQKa5x+UP/KqFsxj4mBg==",
       "dev": true,
       "funding": [
         {
@@ -874,9 +874,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-runtime/node_modules/caniuse-lite": {
-      "version": "1.0.30001444",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001444.tgz",
-      "integrity": "sha512-ecER9xgJQVMqcrxThKptsW0pPxSae8R2RB87LNa+ivW9ppNWRHEplXcDzkCOP4LYWGj8hunXLqaiC41iBATNyg==",
+      "version": "1.0.30001445",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001445.tgz",
+      "integrity": "sha512-8sdQIdMztYmzfTMO6KfLny878Ln9c2M0fc7EH60IjlP4Dc4PiCy7K2Vl3ITmWgOyPgVQKa5x+UP/KqFsxj4mBg==",
       "dev": true,
       "funding": [
         {
@@ -2727,9 +2727,9 @@
       }
     },
     "node_modules/@babel/preset-env/node_modules/caniuse-lite": {
-      "version": "1.0.30001444",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001444.tgz",
-      "integrity": "sha512-ecER9xgJQVMqcrxThKptsW0pPxSae8R2RB87LNa+ivW9ppNWRHEplXcDzkCOP4LYWGj8hunXLqaiC41iBATNyg==",
+      "version": "1.0.30001445",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001445.tgz",
+      "integrity": "sha512-8sdQIdMztYmzfTMO6KfLny878Ln9c2M0fc7EH60IjlP4Dc4PiCy7K2Vl3ITmWgOyPgVQKa5x+UP/KqFsxj4mBg==",
       "dev": true,
       "funding": [
         {
@@ -8103,59 +8103,50 @@
       }
     },
     "node_modules/minisearch": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-5.1.0.tgz",
-      "integrity": "sha512-HkO8dsle9u/8KGKrvia1E6fRjPzEUCDRLIW7bCMb0IGJJ21m4QQ4YgkD972ZtAplwqVodbIjtl96KV3lKggOmA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-6.0.0.tgz",
+      "integrity": "sha512-N7yUgtH5T9iQfdmzI8Dnke8TK+grccrWUsdiwvalGv04hJggOUI/EpWIEQj3v8t7XSi/kSfQ7GdLAS540+GxpQ==",
       "dev": true
     },
     "node_modules/mocha": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.2.tgz",
-      "integrity": "sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
+      "integrity": "sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==",
       "dev": true,
       "dependencies": {
-        "@ungap/promise-all-settled": "1.1.2",
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
         "chokidar": "3.5.3",
-        "debug": "4.3.3",
+        "debug": "4.3.4",
         "diff": "5.0.0",
         "escape-string-regexp": "4.0.0",
         "find-up": "5.0.0",
         "glob": "7.2.0",
-        "growl": "1.10.5",
         "he": "1.2.0",
         "js-yaml": "4.1.0",
         "log-symbols": "4.1.0",
-        "minimatch": "4.2.1",
+        "minimatch": "5.0.1",
         "ms": "2.1.3",
-        "nanoid": "3.3.1",
+        "nanoid": "3.3.3",
         "serialize-javascript": "6.0.0",
         "strip-json-comments": "3.1.1",
         "supports-color": "8.1.1",
-        "which": "2.0.2",
-        "workerpool": "6.2.0",
+        "workerpool": "6.2.1",
         "yargs": "16.2.0",
         "yargs-parser": "20.2.4",
         "yargs-unparser": "2.0.0"
       },
       "bin": {
         "_mocha": "bin/_mocha",
-        "mocha": "bin/mocha"
+        "mocha": "bin/mocha.js"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">= 14.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mochajs"
       }
-    },
-    "node_modules/mocha/node_modules/@ungap/promise-all-settled": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
-      "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
-      "dev": true
     },
     "node_modules/mocha/node_modules/ansi-colors": {
       "version": "4.1.1",
@@ -8355,9 +8346,9 @@
       "dev": true
     },
     "node_modules/mocha/node_modules/debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dev": true,
       "dependencies": {
         "ms": "2.1.2"
@@ -8535,15 +8526,6 @@
         "node": "*"
       }
     },
-    "node_modules/mocha/node_modules/growl": {
-      "version": "1.10.5",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
-      "dev": true,
-      "engines": {
-        "node": ">=4.x"
-      }
-    },
     "node_modules/mocha/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -8650,12 +8632,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/mocha/node_modules/isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
-    },
     "node_modules/mocha/node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -8700,15 +8676,24 @@
       }
     },
     "node_modules/mocha/node_modules/minimatch": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz",
-      "integrity": "sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
+      "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
       "dev": true,
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^2.0.1"
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/mocha/node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/mocha/node_modules/ms": {
@@ -8718,9 +8703,9 @@
       "dev": true
     },
     "node_modules/mocha/node_modules/nanoid": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
-      "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
+      "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
       "dev": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
@@ -8931,25 +8916,10 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/mocha/node_modules/which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/mocha/node_modules/workerpool": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
-      "integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz",
+      "integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==",
       "dev": true
     },
     "node_modules/mocha/node_modules/wrap-ansi": {
@@ -9039,16 +9009,16 @@
       }
     },
     "node_modules/sinon": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-11.1.2.tgz",
-      "integrity": "sha512-59237HChms4kg7/sXhiRcUzdSkKuydDeTiamT/jesUVHshBgL8XAmhgFo0GfK6RruMDM/iRSij1EybmMog9cJw==",
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-15.0.1.tgz",
+      "integrity": "sha512-PZXKc08f/wcA/BMRGBze2Wmw50CWPiAH3E21EOi4B49vJ616vW4DQh4fQrqsYox2aNR/N3kCqLuB0PwwOucQrg==",
       "dev": true,
       "dependencies": {
-        "@sinonjs/commons": "^1.8.3",
-        "@sinonjs/fake-timers": "^7.1.2",
-        "@sinonjs/samsam": "^6.0.2",
+        "@sinonjs/commons": "^2.0.0",
+        "@sinonjs/fake-timers": "10.0.2",
+        "@sinonjs/samsam": "^7.0.1",
         "diff": "^5.0.0",
-        "nise": "^5.1.0",
+        "nise": "^5.1.2",
         "supports-color": "^7.2.0"
       },
       "funding": {
@@ -9057,30 +9027,30 @@
       }
     },
     "node_modules/sinon/node_modules/@sinonjs/commons": {
-      "version": "1.8.6",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.6.tgz",
-      "integrity": "sha512-Ky+XkAkqPZSm3NLBeUng77EBQl3cmeJhITaGHdYH8kjVB+aun3S4XBRti2zt17mtt0mIUDiNxYeoJm6drVvBJQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
+      "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
       "dev": true,
       "dependencies": {
         "type-detect": "4.0.8"
       }
     },
     "node_modules/sinon/node_modules/@sinonjs/fake-timers": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-7.1.2.tgz",
-      "integrity": "sha512-iQADsW4LBMISqZ6Ci1dupJL9pprqwcVFTcOsEmQOEhW+KLCVn/Y4Jrvg2k19fIHCp+iFprriYPTdRcQR8NbUPg==",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.0.2.tgz",
+      "integrity": "sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==",
       "dev": true,
       "dependencies": {
-        "@sinonjs/commons": "^1.7.0"
+        "@sinonjs/commons": "^2.0.0"
       }
     },
     "node_modules/sinon/node_modules/@sinonjs/samsam": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.1.3.tgz",
-      "integrity": "sha512-nhOb2dWPeb1sd3IQXL/dVPnKHDOAFfvichtBf4xV00/rU1QbPCQqKMbvIheIjqwVjh7qIgf2AHTHi391yMOMpQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-7.0.1.tgz",
+      "integrity": "sha512-zsAk2Jkiq89mhZovB2LLOdTCxJF4hqqTToGP0ASWlhp4I1hqOjcfmZGafXntCN7MDC6yySH0mFHrYtHceOeLmw==",
       "dev": true,
       "dependencies": {
-        "@sinonjs/commons": "^1.6.0",
+        "@sinonjs/commons": "^2.0.0",
         "lodash.get": "^4.4.2",
         "type-detect": "^4.0.8"
       }
@@ -9138,24 +9108,6 @@
         "@sinonjs/text-encoding": "^0.7.1",
         "just-extend": "^4.0.2",
         "path-to-regexp": "^1.7.0"
-      }
-    },
-    "node_modules/sinon/node_modules/nise/node_modules/@sinonjs/commons": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
-      "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
-      "dev": true,
-      "dependencies": {
-        "type-detect": "4.0.8"
-      }
-    },
-    "node_modules/sinon/node_modules/nise/node_modules/@sinonjs/fake-timers": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.0.2.tgz",
-      "integrity": "sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==",
-      "dev": true,
-      "dependencies": {
-        "@sinonjs/commons": "^2.0.0"
       }
     },
     "node_modules/sinon/node_modules/path-to-regexp": {
@@ -9494,9 +9446,9 @@
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001444",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001444.tgz",
-          "integrity": "sha512-ecER9xgJQVMqcrxThKptsW0pPxSae8R2RB87LNa+ivW9ppNWRHEplXcDzkCOP4LYWGj8hunXLqaiC41iBATNyg==",
+          "version": "1.0.30001445",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001445.tgz",
+          "integrity": "sha512-8sdQIdMztYmzfTMO6KfLny878Ln9c2M0fc7EH60IjlP4Dc4PiCy7K2Vl3ITmWgOyPgVQKa5x+UP/KqFsxj4mBg==",
           "dev": true
         },
         "chalk": {
@@ -9794,9 +9746,9 @@
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001444",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001444.tgz",
-          "integrity": "sha512-ecER9xgJQVMqcrxThKptsW0pPxSae8R2RB87LNa+ivW9ppNWRHEplXcDzkCOP4LYWGj8hunXLqaiC41iBATNyg==",
+          "version": "1.0.30001445",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001445.tgz",
+          "integrity": "sha512-8sdQIdMztYmzfTMO6KfLny878Ln9c2M0fc7EH60IjlP4Dc4PiCy7K2Vl3ITmWgOyPgVQKa5x+UP/KqFsxj4mBg==",
           "dev": true
         },
         "core-js-compat": {
@@ -11076,9 +11028,9 @@
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001444",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001444.tgz",
-          "integrity": "sha512-ecER9xgJQVMqcrxThKptsW0pPxSae8R2RB87LNa+ivW9ppNWRHEplXcDzkCOP4LYWGj8hunXLqaiC41iBATNyg==",
+          "version": "1.0.30001445",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001445.tgz",
+          "integrity": "sha512-8sdQIdMztYmzfTMO6KfLny878Ln9c2M0fc7EH60IjlP4Dc4PiCy7K2Vl3ITmWgOyPgVQKa5x+UP/KqFsxj4mBg==",
           "dev": true
         },
         "chalk": {
@@ -15428,49 +15380,40 @@
       }
     },
     "minisearch": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-5.1.0.tgz",
-      "integrity": "sha512-HkO8dsle9u/8KGKrvia1E6fRjPzEUCDRLIW7bCMb0IGJJ21m4QQ4YgkD972ZtAplwqVodbIjtl96KV3lKggOmA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-6.0.0.tgz",
+      "integrity": "sha512-N7yUgtH5T9iQfdmzI8Dnke8TK+grccrWUsdiwvalGv04hJggOUI/EpWIEQj3v8t7XSi/kSfQ7GdLAS540+GxpQ==",
       "dev": true
     },
     "mocha": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.2.tgz",
-      "integrity": "sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
+      "integrity": "sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==",
       "dev": true,
       "requires": {
-        "@ungap/promise-all-settled": "1.1.2",
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
         "chokidar": "3.5.3",
-        "debug": "4.3.3",
+        "debug": "4.3.4",
         "diff": "5.0.0",
         "escape-string-regexp": "4.0.0",
         "find-up": "5.0.0",
         "glob": "7.2.0",
-        "growl": "1.10.5",
         "he": "1.2.0",
         "js-yaml": "4.1.0",
         "log-symbols": "4.1.0",
-        "minimatch": "4.2.1",
+        "minimatch": "5.0.1",
         "ms": "2.1.3",
-        "nanoid": "3.3.1",
+        "nanoid": "3.3.3",
         "serialize-javascript": "6.0.0",
         "strip-json-comments": "3.1.1",
         "supports-color": "8.1.1",
-        "which": "2.0.2",
-        "workerpool": "6.2.0",
+        "workerpool": "6.2.1",
         "yargs": "16.2.0",
         "yargs-parser": "20.2.4",
         "yargs-unparser": "2.0.0"
       },
       "dependencies": {
-        "@ungap/promise-all-settled": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
-          "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
-          "dev": true
-        },
         "ansi-colors": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
@@ -15621,9 +15564,9 @@
           "dev": true
         },
         "debug": {
-          "version": "4.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
           "dev": true,
           "requires": {
             "ms": "2.1.2"
@@ -15745,12 +15688,6 @@
             "is-glob": "^4.0.1"
           }
         },
-        "growl": {
-          "version": "1.10.5",
-          "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-          "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
-          "dev": true
-        },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -15827,12 +15764,6 @@
           "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
           "dev": true
         },
-        "isexe": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-          "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-          "dev": true
-        },
         "js-yaml": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -15862,12 +15793,23 @@
           }
         },
         "minimatch": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz",
-          "integrity": "sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
+          "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "^2.0.1"
+          },
+          "dependencies": {
+            "brace-expansion": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+              "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+              "dev": true,
+              "requires": {
+                "balanced-match": "^1.0.0"
+              }
+            }
           }
         },
         "ms": {
@@ -15877,9 +15819,9 @@
           "dev": true
         },
         "nanoid": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
-          "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
+          "version": "3.3.3",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
+          "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
           "dev": true
         },
         "normalize-path": {
@@ -16016,19 +15958,10 @@
             "is-number": "^7.0.0"
           }
         },
-        "which": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-          "dev": true,
-          "requires": {
-            "isexe": "^2.0.0"
-          }
-        },
         "workerpool": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
-          "integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz",
+          "integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==",
           "dev": true
         },
         "wrap-ansi": {
@@ -16096,44 +16029,44 @@
       }
     },
     "sinon": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-11.1.2.tgz",
-      "integrity": "sha512-59237HChms4kg7/sXhiRcUzdSkKuydDeTiamT/jesUVHshBgL8XAmhgFo0GfK6RruMDM/iRSij1EybmMog9cJw==",
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-15.0.1.tgz",
+      "integrity": "sha512-PZXKc08f/wcA/BMRGBze2Wmw50CWPiAH3E21EOi4B49vJ616vW4DQh4fQrqsYox2aNR/N3kCqLuB0PwwOucQrg==",
       "dev": true,
       "requires": {
-        "@sinonjs/commons": "^1.8.3",
-        "@sinonjs/fake-timers": "^7.1.2",
-        "@sinonjs/samsam": "^6.0.2",
+        "@sinonjs/commons": "^2.0.0",
+        "@sinonjs/fake-timers": "10.0.2",
+        "@sinonjs/samsam": "^7.0.1",
         "diff": "^5.0.0",
-        "nise": "^5.1.0",
+        "nise": "^5.1.2",
         "supports-color": "^7.2.0"
       },
       "dependencies": {
         "@sinonjs/commons": {
-          "version": "1.8.6",
-          "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.6.tgz",
-          "integrity": "sha512-Ky+XkAkqPZSm3NLBeUng77EBQl3cmeJhITaGHdYH8kjVB+aun3S4XBRti2zt17mtt0mIUDiNxYeoJm6drVvBJQ==",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
+          "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
           "dev": true,
           "requires": {
             "type-detect": "4.0.8"
           }
         },
         "@sinonjs/fake-timers": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-7.1.2.tgz",
-          "integrity": "sha512-iQADsW4LBMISqZ6Ci1dupJL9pprqwcVFTcOsEmQOEhW+KLCVn/Y4Jrvg2k19fIHCp+iFprriYPTdRcQR8NbUPg==",
+          "version": "10.0.2",
+          "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.0.2.tgz",
+          "integrity": "sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==",
           "dev": true,
           "requires": {
-            "@sinonjs/commons": "^1.7.0"
+            "@sinonjs/commons": "^2.0.0"
           }
         },
         "@sinonjs/samsam": {
-          "version": "6.1.3",
-          "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.1.3.tgz",
-          "integrity": "sha512-nhOb2dWPeb1sd3IQXL/dVPnKHDOAFfvichtBf4xV00/rU1QbPCQqKMbvIheIjqwVjh7qIgf2AHTHi391yMOMpQ==",
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-7.0.1.tgz",
+          "integrity": "sha512-zsAk2Jkiq89mhZovB2LLOdTCxJF4hqqTToGP0ASWlhp4I1hqOjcfmZGafXntCN7MDC6yySH0mFHrYtHceOeLmw==",
           "dev": true,
           "requires": {
-            "@sinonjs/commons": "^1.6.0",
+            "@sinonjs/commons": "^2.0.0",
             "lodash.get": "^4.4.2",
             "type-detect": "^4.0.8"
           }
@@ -16185,26 +16118,6 @@
             "@sinonjs/text-encoding": "^0.7.1",
             "just-extend": "^4.0.2",
             "path-to-regexp": "^1.7.0"
-          },
-          "dependencies": {
-            "@sinonjs/commons": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
-              "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
-              "dev": true,
-              "requires": {
-                "type-detect": "4.0.8"
-              }
-            },
-            "@sinonjs/fake-timers": {
-              "version": "10.0.2",
-              "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.0.2.tgz",
-              "integrity": "sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==",
-              "dev": true,
-              "requires": {
-                "@sinonjs/commons": "^2.0.0"
-              }
-            }
           }
         },
         "path-to-regexp": {

--- a/package.json
+++ b/package.json
@@ -49,9 +49,9 @@
     "grunt-git-authors": "^3.2.0",
     "grunt-mocha-test": "^0.13.2",
     "grunt-retire": "^1.0.3",
-    "minisearch": "^5.0.0",
-    "mocha": "^9.2.1",
-    "sinon": "^11.1.2"
+    "minisearch": "^6.0.0",
+    "mocha": "^10.2.0",
+    "sinon": "^15.0.1"
   },
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
This update started as a fix for an issue on the server with updating the search index when a page is forked over an existing page. While investigating that issue an error was spotted with the regex that removes HTML tags.

This PR includes:
* a correction to the regex used to remove HTML tags,
* a simplification of the code made possible by minisearch@6, which removes the need for a pages original text when removing it from, or updating it, in the index.