### PR TITLE
Add plugin successor mapping

### DIFF
--- a/lib/plugin.coffee
+++ b/lib/plugin.coffee
@@ -135,6 +135,9 @@ plugin.wrap = (name, p) ->
   return p
 
 plugin.get = plugin.getPlugin = (name, callback) ->
+  if window.pluginSuccessor[name]
+    wiki.log('plugin successor', name, window.pluginSuccessor[name])
+    name = window.pluginSuccessor[name] 
   return loadingScripts[name].then(callback) if loadingScripts[name]
   loadingScripts[name] = new Promise (resolve, _reject) ->
     return resolve(window.plugins[name]) if window.plugins[name]

--- a/lib/plugins.coffee
+++ b/lib/plugins.coffee
@@ -10,3 +10,8 @@ window.plugins =
   #image: plugin.wrap('image', require './image')
   future: plugin.wrap('future', require './future')
   importer: plugin.wrap('importer', require './importer')
+
+# mapping between old plugins and their successor
+window.pluginSuccessor =
+  federatedWiki: 'reference'
+  mathjax: 'math'


### PR DESCRIPTION
Add a mapping between old plugins and their successors.

There was a thought this functionality was previously included when the `federatedwiki` plugin was replaced by `reference` plugin. But, that seems to have been lost along the way.

Added to support the replacement of the implementation specific `mathjax` plugin with the `math` plugin.