### PR TITLE
fix issue with refreshing failed site

### DIFF
--- a/lib/neighbors.coffee
+++ b/lib/neighbors.coffee
@@ -41,8 +41,9 @@ formatNeighborTitle = (site) ->
       title += "#{pageCount} pages\n"
   catch error
     console.info '+++ sitemap not valid for ', site
-  title += "Updated #{util.formatElapsedTime(sites[site].lastModified)}"
-  title += ", next refresh #{util.formatDelay(sites[site].nextCheck)}" if sites[site].nextCheck - Date.now() > 0
+  if sites[site].lastModified != 0
+    title += "Updated #{util.formatElapsedTime(sites[site].lastModified)}"
+    title += ", next refresh #{util.formatDelay(sites[site].nextCheck)}" if sites[site].nextCheck - Date.now() > 0
   return title
   
 

--- a/lib/neighbors.coffee
+++ b/lib/neighbors.coffee
@@ -75,7 +75,7 @@ bind = ->
       # add handling refreshing neighbor that has failed
       if $(e.target).parent().hasClass('fail')
         $(e.target).parent().removeClass('fail').addClass('wait')
-        site = $(e.target).attr('title')
+        site = $(e.target).attr('title').split('\n')[0]
         wiki.site(site).refresh () ->
           console.log 'about to retry neighbor'
           neighborhood.retryNeighbor(site)


### PR DESCRIPTION
If the flag of a failed site is clicked on, in the neighbourhood bar, the site adapter will retest how to access that wiki.

However, when adding sitemap refresh the age of the sitemap, and refresh interval, was added to the flag's tooltip.

This update will not add that extra information, when the sitemap fails to load, but also filters it out to provide some extra protection.