### PR TITLE
update jquery version in runtest

### DIFF
--- a/client/runtests.html
+++ b/client/runtests.html
@@ -4,9 +4,9 @@
     <meta charset="utf-8">
     <title>SFW Mocha Tests</title>
     <link rel="stylesheet" href="/test/mocha.css" />
-    <script src='/js/jquery-2.2.4.js' type='text/javascript'></script>
-    <script src='/js/jquery-migrate-1.4.1.js' type='text/javascript'></script>
-    <script src='/js/jquery-ui/1.11.4/jquery-ui.min.js' type='text/javascript'></script>
+    <script src='/js/jquery-3.6.3.js' type='text/javascript'></script>
+    <script src='/js/jquery-migrate-3.4.0.js' type='text/javascript'></script>
+    <script src='/js/jquery-ui/1.13.2/jquery-ui.min.js' type='text/javascript'></script>
 
     <script src='/test/mocha.js' type='text/javascript'></script>
     <script>


### PR DESCRIPTION
Found the reference to the old version of jQuery that was causing Dependabot to raise an alert. As the version of jQuery being referenced is not included here, so the real problem would be that `runtest.html` would not have worked.