### PR TITLE
Adding support for Login to View

### DIFF
--- a/lib/legacy.coffee
+++ b/lib/legacy.coffee
@@ -34,8 +34,9 @@ preLoadEditors = (catalog) ->
     )
 
 wiki.origin.get 'system/factories.json', (error, data) ->
-  window.catalog = data
-  preLoadEditors data
+  if Array.isArray(data)
+    window.catalog = data
+    preLoadEditors data
 
 $ ->
   dialog.emit()

--- a/lib/siteAdapter.coffee
+++ b/lib/siteAdapter.coffee
@@ -348,7 +348,7 @@ siteAdapter.site = (site) ->
           url: url
           xhrFields: { withCredentials: useCredentials }
           success: (data, code, xhr) ->
-            if data.title is 'Login Required' and !url.includes('login-required') and credentialsNeeded[site] isnt true
+            if ((route is 'system/sitemap.json' and Array.isArray(data) and data[0] is 'Login Required') or data.title is 'Login Required') and !url.includes('login-required') and credentialsNeeded[site] isnt true
               credentialsNeeded[site] = true
               getContent route, (err, page) ->
                 if !err

--- a/lib/siteAdapter.coffee
+++ b/lib/siteAdapter.coffee
@@ -158,7 +158,11 @@ siteAdapter.origin = {
       type: 'GET'
       dataType: 'json'
       url: "/#{route}"
-      success: (page) -> done null, page
+      success: (page, code, xhr) ->
+        if route is 'system/sitemap.json'
+          done null, { data: page, lastModified: Date.parse(xhr.getResponseHeader('Last-Modified') )}
+        else
+          done null, page
       error: (xhr, type, msg) -> done {msg, xhr}, null
   getIndex: (route, callback) ->
     done = (err, value) -> if (callback) then callback(err, value)
@@ -343,7 +347,7 @@ siteAdapter.site = (site) ->
           dataType: 'json'
           url: url
           xhrFields: { withCredentials: useCredentials }
-          success: (data) ->
+          success: (data, code, xhr) ->
             if data.title is 'Login Required' and !url.includes('login-required') and credentialsNeeded[site] isnt true
               credentialsNeeded[site] = true
               getContent route, (err, page) ->
@@ -354,7 +358,10 @@ siteAdapter.site = (site) ->
                   credentialsNeeded[site] = false
                   done err, page
             else
-              done null, data
+              if route is 'system/sitemap.json'
+                done null, { data, lastModified: Date.parse(xhr.getResponseHeader('Last-Modified')) }
+              else
+                done null, data
               Promise.resolve(data) unless callback
           error: (xhr, type, msg) ->
             done {msg, xhr}, null


### PR DESCRIPTION
Some changes related to Login to View.

Refactoring the sitemap handling to use siteAdapter, so we use its support for login to view, and adding support for returning lastModified date when returning sitemaps.

Adding 'login required' support for sitemaps - these will often be the second resource fetched from a remote wiki, after the flag.