### PR TITLE
Address the forever spinning flag when wiki is unreachable.

### DIFF
--- a/lib/neighborhood.coffee
+++ b/lib/neighborhood.coffee
@@ -40,13 +40,14 @@ populateSiteInfoFor = (site,neighborInfo)->
     neighborInfo.sitemapRequestInflight = true
 
     wiki.site(site).get 'system/sitemap.json', (err, gotData) ->
-      { data, lastModified } = gotData
       neighborInfo.sitemapRequestInflight = false
       if err
         transition site, 'fetch', 'fail'
         wiki.site(site).refresh () ->
           # empty function
         throw new Error('Unable to fetch sitemap')
+
+      { data, lastModified } = gotData
       
       if isNaN lastModified
         lastModified = 0


### PR DESCRIPTION
Addressing the ever spinning flag, caused by the data destructure failing, so the error handling is never reached.

Error message from console:
 Uncaught TypeError: e is null
    u client.max.js:1978
    r client.max.js:5035
    get client.max.js:5095
    u client.max.js:1976
    n client.max.js:2028
    setTimeout handler*r client.max.js:2035
    registerNeighbor client.max.js:2053
    load_sites welcome-visitors line 2 > injectedScript:42
    bind welcome-visitors line 2 > injectedScript:186
    jQuery 2