### PR TITLE
Copy is not the same as move!

### DIFF
--- a/lib/refresh.coffee
+++ b/lib/refresh.coffee
@@ -123,7 +123,7 @@ changeMouseCursor = (e, ui) ->
   moveBetweenDuplicatePages = not moveWithinPage and \
     $sourcePage.attr('id') == $destinationPage.attr('id')
   copying = sourceIsReadOnly or (e.shiftKey and not moveWithinPage)
-  if destinationIsGhost or moveBetweenDuplicatePages
+  if destinationIsGhost or (moveBetweenDuplicatePages and not e.shiftKey)
     $('body').css('cursor', 'no-drop')
     $('.shadow-copy').hide()
   else if copying

--- a/lib/refresh.coffee
+++ b/lib/refresh.coffee
@@ -73,6 +73,7 @@ handleDrop = (evt, ui, originalIndex, originalOrder) ->
 
   moveWithinPage = equals($sourcePage, $destinationPage)
   moveBetweenDuplicatePages = not moveWithinPage and \
+    not evt.shiftKey and \
     $sourcePage.attr('id') == $destinationPage.attr('id')
 
   removedTo = {


### PR DESCRIPTION
Changes to allow items to be copied from a remote page with the same slug.