### PR TITLE
align items when starting targeting

### DIFF
--- a/lib/target.coffee
+++ b/lib/target.coffee
@@ -5,6 +5,7 @@
 # that highlighting can be immediate when requested.
 
 targeting = false
+$item = null
 item = null
 itemElem = null
 action = null
@@ -28,10 +29,13 @@ bind = ->
 
 startTargeting = (e) ->
   targeting = e.shiftKey
-  if targeting
+  if targeting and $item
     $('.emit').addClass('highlight')
     if id = item || action
       $("[data-id=#{id}]").addClass('target')
+      key = ($page = $(this).parents('.page:first')).data('key')
+      place = $item.offset().top
+      $('.page').trigger('align-item', {key, id:item, place})
     if itemElem
       consumed = itemElem.consuming
       if consumed
@@ -79,6 +83,7 @@ leaveItem = (e) ->
     $('.item, .action').removeClass('target')
     $('.item').removeClass('consumed')
   item = null
+  $item = null
   itemElem = null
 
 


### PR DESCRIPTION
The comments on `target.coffee` mention
> Target handles hovers over items and actions. Other visible
items and actions with the same id will highlight. In some cases
an event is generated inviting other pages to scroll the item
into view. Target tracks hovering even when not requested so
that highlighting can be immediate when requested.

*Some cases* appears to be only while moving the mouse over an item while holding the shift key down.

The change here will amends the keydown event, start of requesting highlighting, to also trigger the event to scroll the item into view on other pages.