### PR TITLE
Handle internal links that start/end with spaces

### DIFF
--- a/client/style/style.css
+++ b/client/style/style.css
@@ -12,7 +12,7 @@ a {
   text-decoration: none; }
 
 /* highlight links that have slug starting or ending with a `-`, a space in the page title */
-a[href^='/-'], a[href$='-.html'] {
+a.spaced {
   text-decoration: wavy underline crimson;
 }
 

--- a/client/style/style.css
+++ b/client/style/style.css
@@ -11,6 +11,11 @@ pre.error {
 a {
   text-decoration: none; }
 
+/* highlight links that have slug starting or ending with a `-`, a space in the page title */
+a[href^='/-'], a[href$='-.html'] {
+  text-decoration: wavy underline crimson;
+}
+
 a img {
   border: 0; }
 

--- a/client/style/style.css
+++ b/client/style/style.css
@@ -11,8 +11,8 @@ pre.error {
 a {
   text-decoration: none; }
 
-/* highlight links that have slug starting or ending with a `-`, a space in the page title */
-a.spaced {
+/* highlight links that have title starting or ending with a space. */
+body:has(#security>a>i.fa-lock-open) a.spaced {
   text-decoration: wavy underline crimson;
 }
 

--- a/client/style/style.css
+++ b/client/style/style.css
@@ -12,7 +12,7 @@ a {
   text-decoration: none; }
 
 /* highlight links that have title starting or ending with a space. */
-body:has(#security>a>i.fa-lock-open) a.spaced {
+body:has(footer span[style=""]) a.spaced {
   text-decoration: wavy underline crimson;
 }
 

--- a/lib/future.coffee
+++ b/lib/future.coffee
@@ -11,8 +11,11 @@ refresh = require './refresh'
 emit = ($item, item) ->
 
   $item.append """#{item.text}"""
-
-  $item.append """<br><br><button class="create">create</button> new blank page"""
+  proposedSlug = $item.parents('.page:first')[0].id
+  if wiki.asSlug(item.title) isnt proposedSlug
+    $item.append "<p>The title for for new page has spaces at the beginning and/or the end.</p>"
+  else
+    $item.append """<br><br><button class="create">create</button> new blank page"""
 
   if transport = item.create?.source?.transport
     $item.append """<br><button class="transport" data-slug=#{item.slug}>create</button> transport from #{transport}"""

--- a/lib/future.coffee
+++ b/lib/future.coffee
@@ -13,7 +13,7 @@ emit = ($item, item) ->
   $item.append """#{item.text}"""
   proposedSlug = $item.parents('.page:first')[0].id
   if wiki.asSlug(item.title) isnt proposedSlug
-    $item.append "<p>The proposed title has spaces at the beginning, the end, or both. You will want to fix that before creating a new page.</p>"
+    $item.append "<p style='font-weight: 500;'>Page titles with leading/trailing spaces can not be used to create a new page.</p>"
   else
     $item.append """<br><br><button class="create">create</button> new blank page"""
 

--- a/lib/future.coffee
+++ b/lib/future.coffee
@@ -13,7 +13,7 @@ emit = ($item, item) ->
   $item.append """#{item.text}"""
   proposedSlug = $item.parents('.page:first')[0].id
   if wiki.asSlug(item.title) isnt proposedSlug
-    $item.append "<p>The title for for new page has spaces at the beginning and/or the end.</p>"
+    $item.append "<p>The proposed title has spaces at the beginning, the end, or both. You will want to fix that before creating a new page.</p>"
   else
     $item.append """<br><br><button class="create">create</button> new blank page"""
 

--- a/lib/resolve.coffee
+++ b/lib/resolve.coffee
@@ -38,8 +38,9 @@ resolve.resolveLinks = (string, sanitize=escape) ->
 
   internal = (match, name) ->
     slug = asSlug name
+    styling = if name is name.trim() then 'internal' else 'internal spaced'
     if slug.length
-      stash """<a class="internal" href="/#{slug}.html" data-page-name="#{slug}" title="#{resolve.resolutionContext.join(' => ')}">#{escape name}</a>"""
+      stash """<a class="#{styling}" href="/#{slug}.html" data-page-name="#{slug}" title="#{resolve.resolutionContext.join(' => ')}">#{escape name}</a>"""
     else
       match
 

--- a/test/wiki.coffee
+++ b/test/wiki.coffee
@@ -17,6 +17,15 @@ describe 'wiki', ->
         expect(s).to.contain 'href="/world.html"'
       it 'should have data-page-name', ->
         expect(s).to.contain 'data-page-name="world"'
+    
+    describe 'internal links with space', ->
+      s = wiki.resolveLinks "hello [[ world]]"
+      it 'should be class spaced', ->
+        expect(s).to.contain 'class="internal spaced"'
+      it 'should relative reference html', ->
+        expect(s).to.contain 'href="/-world.html"'
+      it 'should have data-page-name', ->
+        expect(s).to.contain 'data-page-name="-world"'
 
     describe 'external links', ->
       s = wiki.resolveLinks "hello [http://world.com?foo=1&bar=2 world]"


### PR DESCRIPTION
Addressing an old usability trap (#284): internal links that start/end with spaces look much the same as one that doesn't, but creates a different name for the wiki page file.

[[space]] -> 'space',
[[ space]] -> '-space'

Simply trimming the space off of the internal link is not a solution, as it would leave those pages that already exist, with such names, as unreachable.

In this change we add some styling to highlight internal links that start/end with a space. <img width="490" alt="Screenshot 2024-02-19 at 10 49 06" src="https://github.com/fedwiki/wiki-client/assets/1552489/fe98cdbe-b30f-4fbd-b4b7-17ab38819700"> 

On the "_We could not find this page._" page, the create page line is replaced with a message. _A better message is needed._


