### PR TITLE
fix: handle case when site has a port number in URL

### DIFF
--- a/lib/siteAdapter.coffee
+++ b/lib/siteAdapter.coffee
@@ -70,7 +70,7 @@ findAdapterQ = queue( (task, done) ->
   if sitePrefix[site]?
     done sitePrefix[site]
 
-  if site.split('.').at(-1) is 'localhost'
+  if site.split('.').at(-1).split(':')[0] is 'localhost'
     testURL = "http://#{site}/favicon.png"
   else
     testURL = "//#{site}/favicon.png"


### PR DESCRIPTION
As well as removing any subdomains, also remove any port before checking if the remote is a wiki on localhost.