### PR TITLE
Add missing item id

### DIFF
--- a/lib/search.coffee
+++ b/lib/search.coffee
@@ -142,6 +142,7 @@ createSearch = ({neighborhood})->
     """ })
     for result in searchResults.finds
       resultPage.story.push({
+        "id": random.itemId()
         "type": "reference"
         "site": result.site
         "slug": result.page.slug


### PR DESCRIPTION
The reference items on the search results ghost page were missing an itemId. This causes a problem elsewhere.

Thanks @dobbs for raising this during Sunday's call.