### PR TITLE
Use dynamic import to load plugin client code

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -52,7 +52,7 @@ module.exports = function (grunt) {
         src: ['./client.coffee'],
         dest: 'client/client.max.js',
         options: {
-          transform: [['coffeeify', {transpile: {presets: ['@babel/preset-env'], plugins: ['@babel/plugin-transform-runtime']}}]],
+          transform: [['coffeeify', {transpile: {presets: [[ '@babel/preset-env', { "exclude": ["proposal-dynamic-import"]}]], plugins: ['@babel/plugin-transform-runtime']}}]],
           browserifyOptions: {
             extensions: ".coffee"
           }
@@ -65,7 +65,7 @@ module.exports = function (grunt) {
         src: ['./testclient.coffee'],
         dest: 'client/test/testclient.js',
         options: {
-          transform: [['coffeeify', {transpile: {presets: ['@babel/preset-env'], plugins: ['@babel/plugin-transform-runtime']}}]],
+          transform: [['coffeeify', {transpile: {presets: [[ '@babel/preset-env', { "exclude": ["proposal-dynamic-import"]}]], plugins: ['@babel/plugin-transform-runtime']}}]],
           browserifyOptions: {
             extensions: ".coffee"
           }

--- a/lib/plugin.coffee
+++ b/lib/plugin.coffee
@@ -17,14 +17,9 @@ escape = (s) ->
 # define loadScript that allows fetching a script.
 # see example in http://api.jquery.com/jQuery.getScript/
 
-loadScript = (url, options) ->
+loadScript = (url) ->
   console.log("loading url:", url)
-  options = $.extend(options or {},
-    dataType: "script"
-    cache: true
-    url: url
-  )
-  $.ajax options
+  import(url)
 
 scripts = []
 loadingScripts = {}
@@ -33,10 +28,10 @@ getScript = plugin.getScript = (url, callback = () ->) ->
     callback()
   else
     loadScript url
-      .done ->
+      .then ->
         scripts.push url
         callback()
-      .fail (_jqXHR, _textStatus, err) ->
+      .catch (err) ->
         console.log('getScript: Failed to load:', url, err)
         callback()
 


### PR DESCRIPTION
I know it seems insane, but this seems to just work.

By using the built in import expression we can dynamically load scrips like we have been, but those scrips in turn can now use import statements and easily load their own dependencies without a build step. For a plugin that would often mean pulling from its own plugin folder like
```js
import { test } from '/plugins/mech/test.mjs'
```

The grunt change is required to prevent babel from replacing native dynamic imports with it's own stuff. This is the only call to loadScript so it was easy to cut the unused options argument, and convert the response to normal promise methods.

This is going to require a lot of testing.