### PR TITLE
Extract from currentItem, not item

### DIFF
--- a/lib/neighborhood.coffee
+++ b/lib/neighborhood.coffee
@@ -164,7 +164,7 @@ extractPageText = (pageText, currentItem, currentIndex) ->
         when 'paragraph', 'markdown', 'html', 'reference', 'image', 'pagefold', 'math', 'mathjax', 'code'
           pageText += extractItemText currentItem.text
         when 'audio', 'video', 'frame'
-          pageText += extractItemText(item.text.split(/\r\n?|\n/)
+          pageText += extractItemText(currentItem.text.split(/\r\n?|\n/)
             .map((line) ->
               firstWord = line.split(/\p{White_Space}/u)[0]
               if firstWord.startsWith('http') or firstWord.toUpperCase() is firstWord or firstWord.startsWith('//')


### PR DESCRIPTION
A fix for incorrectly using the non-existent `item`, rather than `currentItem` in `extractPageText()`.

Causes the re-index after editing audio,frame or video items to fail and the client's index to fail. 