### PR TITLE
Remove underscore from the production client.

### DIFF
--- a/lib/factory.js
+++ b/lib/factory.js
@@ -276,17 +276,17 @@ var arrayToJson = function(array) {
   const cols = array.shift();
   const rowToObject = function(row) {
     const obj = {};
-    for (var [k, v] of Array.from(_.zip(cols, row))) {
+    row.forEach(function (v, idx) {
+      let k = cols[idx]
       if ((v != null) && (v.match(/\S/)) && (v !== 'NULL')) { obj[k] = v; }
-    }
+    })
     return obj;
   };
-  return (() => {
-    const result = [];
-    for (var row of Array.from(array)) {       result.push(rowToObject(row));
-    }
-    return result;
-  })();
+  const result = [];
+  for (var row of array) {
+    result.push(rowToObject(row));
+  }
+  return result;
 };
 
 

--- a/lib/neighborhood.js
+++ b/lib/neighborhood.js
@@ -11,7 +11,6 @@
 // slowly and keeps track of get requests in flight.
 
 let neighborhood;
-const _ = require('underscore');
 const miniSearch = require('minisearch');
 
 module.exports = (neighborhood = {});
@@ -170,7 +169,7 @@ neighborhood.deleteFromSitemap = function(pageObject){
   return $('body').trigger('delete-neighbor-done', site);
 };
 
-neighborhood.listNeighbors = () => _.keys( neighborhood.sites );
+neighborhood.listNeighbors = () => Object.keys(neighborhood.sites);
 
 // Page Search
 

--- a/lib/page.js
+++ b/lib/page.js
@@ -18,7 +18,6 @@ const {
 const random = require('./random');
 const revision = require('./revision');
 const synopsis = require('./synopsis');
-const _ = require('underscore');
 
 // http://pragprog.com/magazines/2011-08/decouple-your-apps-with-eventdriven-coffeescript
 const {EventEmitter} = require('events');
@@ -50,7 +49,7 @@ var newPage = function(json, site) {
   const getContext = function() {
     const context = ['view'];
     if (isRemote()) { context.push(site); }
-    const addContext = function(site) { if ((site != null) && !_.include(context, site)) { return context.push(site); } };
+    const addContext = function(site) { if ((site != null) && !context.includes(site)) { return context.push(site); } };
     for (var action of Array.from(page.journal.slice(0).reverse())) { addContext(action != null ? action.site : undefined); }
     return context;
   };
@@ -89,7 +88,7 @@ var newPage = function(json, site) {
     for (var action of Array.from(page.journal)) {
       if ((action != null ? action.site : undefined) != null) { neighbors.push(action.site); }
     }
-    return _.uniq(neighbors);
+    return Array.from(new Set(neighbors));
   };
 
   const getTitle = () => page.title;
@@ -164,7 +163,7 @@ var newPage = function(json, site) {
 
 
   const addItem = function(item) {
-    item = _.extend({}, {id: random.itemId()}, item);
+    item = Object.assign({}, {id: random.itemId()}, item);
     return page.story.push(item);
   };
 

--- a/lib/pageHandler.js
+++ b/lib/pageHandler.js
@@ -12,7 +12,6 @@
 // incremental updates and implicit forks when pages are edited.
 
 let pageHandler;
-const _ = require('underscore');
 
 const state = require('./state');
 const revision = require('./revision');
@@ -126,7 +125,7 @@ pageHandler.get = function({whenGotten,whenNotGotten,pageInformation}  ) {
     pageInformation,
     whenGotten,
     whenNotGotten,
-    localContext: _.clone(pageHandler.context)
+    localContext: pageHandler.context.slice()
   });
 };
 

--- a/lib/refresh.js
+++ b/lib/refresh.js
@@ -97,7 +97,7 @@ const handleDrop = function(evt, ui, originalIndex, originalOrder) {
 
   if (moveWithinPage) {
     const order = getStoryItemOrder($item.parents('.story:first'));
-    if (arrayShallowEqual(order, originalOrder)) {
+    if (JSON.stringify(order) !==  JSON.stringify(originalOrder)) {
       $('.shadow-copy').remove();
       $item.empty();
       index = $(".item").index($item);
@@ -587,20 +587,5 @@ const cycle = function($page) {
   });
   return promise;
 };
-
-function arrayShallowEqual (a, b) {
-  if (!Array.isArray(a) || !Array.isArray(b)) {
-    return false
-  }
-  if (a.length !== b.length) {
-    return false
-  }
-  for (var i = 0; i < a.length; i++) {
-    if (a[i] !== b[i]) {
-      return false
-    }
-  }
-  return true
-}
 
 module.exports = {cycle, emitTwins, buildPage, rebuildPage, newFuturePage};

--- a/lib/refresh.js
+++ b/lib/refresh.js
@@ -12,8 +12,6 @@
 // The various calling conventions are due to async
 // requirements and the work of many hands.
 
-const _ = require('underscore');
-
 const pageHandler = require('./pageHandler');
 const plugin = require('./plugin');
 const state = require('./state');
@@ -99,7 +97,7 @@ const handleDrop = function(evt, ui, originalIndex, originalOrder) {
 
   if (moveWithinPage) {
     const order = getStoryItemOrder($item.parents('.story:first'));
-    if (!_.isEqual(order, originalOrder)) {
+    if (arrayShallowEqual(order, originalOrder)) {
       $('.shadow-copy').remove();
       $item.empty();
       index = $(".item").index($item);
@@ -514,7 +512,7 @@ const newFuturePage = function(title, create) {
   for (var site in neighborhood.sites) {
     var info = neighborhood.sites[site];
     if (info.sitemap != null) {
-      var result = _.find(info.sitemap, each => each.slug === slug);
+      var result = info.sitemap.find(each => each.slug === slug);
       if (result != null) {
         hits.push({
           "type": "reference",
@@ -589,5 +587,20 @@ const cycle = function($page) {
   });
   return promise;
 };
+
+function arrayShallowEqual (a, b) {
+  if (!Array.isArray(a) || !Array.isArray(b)) {
+    return false
+  }
+  if (a.length !== b.length) {
+    return false
+  }
+  for (var i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) {
+      return false
+    }
+  }
+  return true
+}
 
 module.exports = {cycle, emitTwins, buildPage, rebuildPage, newFuturePage};


### PR DESCRIPTION
The replacements for the _ functions aren't as general as what was there, but they all seem to suit our purposes.

Underscore is still used in the tests.