### PR TITLE
Update future.js

### DIFF
--- a/lib/future.js
+++ b/lib/future.js
@@ -38,7 +38,7 @@ const emit = function ($item, item) {
 
   if (item.context?.length > 0 || (isSecureContext && !location.hostname.endsWith('localhost'))) {
     $item.append(`\
-<p>Some possible places to look for this page, if it exists.</p>\
+<p>Some possible places to look for this page, if it exists:</p>\
 `)
   }
 
@@ -68,11 +68,11 @@ const emit = function ($item, item) {
   ${offerPages.join('\n')}
 </div>\
 `)
-    } else {
       offerAltLineup = false
+    } else {
       $item.append(`\
 <div>
-  <p>None of the expected places were unreachable.</p>
+  <p>None of the expected places were reachable.</p>
 </div>\
 `)
     }


### PR DESCRIPTION
Change the logic of when the alternate lineup is suggested over http. It's currently suggested only when there were alternate pages to offer that could be reached, and not when none of those pages could be reached. This seems backwards.

also, Fix what seems to be a typo.