### PR TITLE
Improve handling of item type changes

### DIFF
--- a/lib/editor.js
+++ b/lib/editor.js
@@ -62,6 +62,7 @@ var textEditor = function ($item, item, option) {
     if ((e.ctrlKey || e.metaKey) && e.which === 77) {
       //ctrl-m for menu
       e.preventDefault()
+      $item.data('originalType', item.type)
       $item.removeClass(item.type).addClass((item.type = 'factory'))
       $textarea.trigger('focusout')
       return false
@@ -133,10 +134,13 @@ var textEditor = function ($item, item, option) {
         }
         pageHandler.put($page, { type: 'add', id: item.id, item, after: option.after })
       } else {
-        if (item[option.field || 'text'] === original) {
-          return
+        if (
+          item[option.field || 'text'] !== original ||
+          (item.type != 'factory' && $item.data('originalType') && $item.data('originalType') != item.type)
+        ) {
+          $item.removeData('originalType')
+          pageHandler.put($page, { type: 'edit', id: item.id, item })
         }
-        pageHandler.put($page, { type: 'edit', id: item.id, item })
       }
     } else {
       if (!option.after) {


### PR DESCRIPTION
Addressing an issue where item type changes, made via the ctrl/cmd+m shortcut, were not being saved unless the item content was also edited.