### PR TITLE
Remove federation search from page footer

### DIFF
--- a/lib/legacy.js
+++ b/lib/legacy.js
@@ -345,48 +345,50 @@ from an export file dated ${file.lastModifiedDate}.\
       console.log('in .score...')
       $('.main').trigger('thumb', $(e.target).data('thumb'))
     })
-    .on('click', 'a.search', function (e) {
-      const $page = $(e.target).parents('.page')
-      const key = $page.data('key')
-      const pageObject = lineup.atKey(key)
-      const resultPage = newPage()
-      resultPage.setTitle(`Search from '${pageObject.getTitle()}'`)
-      resultPage.addParagraph(
-        `Search for pages related to '${pageObject.getTitle()}'.
-Each search on this page will find pages related in a different way.
-Choose the search of interest. Be patient.`,
-      )
-      resultPage.addParagraph('Find pages with links to this title.')
-      resultPage.addItem({
-        type: 'search',
-        text: `SEARCH LINKS ${pageObject.getSlug()}`,
-      })
-      resultPage.addParagraph('Find pages with titles similar to this title.')
-      resultPage.addItem({
-        type: 'search',
-        text: `SEARCH SLUGS ${pageObject.getSlug()}`,
-      })
-      resultPage.addParagraph('Find pages neighboring  this site.')
-      resultPage.addItem({
-        type: 'search',
-        text: `SEARCH SITES ${pageObject.getRemoteSite(location.host)}`,
-      })
-      resultPage.addParagraph('Find pages sharing any of these items.')
-      resultPage.addItem({
-        type: 'search',
-        text: `SEARCH ANY ITEMS ${pageObject
-          .getRawPage()
-          .story.map(item => item.id)
-          .join(' ')}`,
-      })
-      if (!e.shiftKey) {
-        $page.nextAll().remove()
-      }
-      if (!e.shiftKey) {
-        lineup.removeAllAfterKey(key)
-      }
-      link.showResult(resultPage)
-    })
+    // removed as federation search is not available. Replace when there is a replacement.
+    // search plugin has also been removed and will need replacing when a replacement federation search is available.
+    //     .on('click', 'a.search', function (e) {
+    //       const $page = $(e.target).parents('.page')
+    //       const key = $page.data('key')
+    //       const pageObject = lineup.atKey(key)
+    //       const resultPage = newPage()
+    //       resultPage.setTitle(`Search from '${pageObject.getTitle()}'`)
+    //       resultPage.addParagraph(
+    //         `Search for pages related to '${pageObject.getTitle()}'.
+    // Each search on this page will find pages related in a different way.
+    // Choose the search of interest. Be patient.`,
+    //       )
+    //       resultPage.addParagraph('Find pages with links to this title.')
+    //       resultPage.addItem({
+    //         type: 'search',
+    //         text: `SEARCH LINKS ${pageObject.getSlug()}`,
+    //       })
+    //       resultPage.addParagraph('Find pages with titles similar to this title.')
+    //       resultPage.addItem({
+    //         type: 'search',
+    //         text: `SEARCH SLUGS ${pageObject.getSlug()}`,
+    //       })
+    //       resultPage.addParagraph('Find pages neighboring  this site.')
+    //       resultPage.addItem({
+    //         type: 'search',
+    //         text: `SEARCH SITES ${pageObject.getRemoteSite(location.host)}`,
+    //       })
+    //       resultPage.addParagraph('Find pages sharing any of these items.')
+    //       resultPage.addItem({
+    //         type: 'search',
+    //         text: `SEARCH ANY ITEMS ${pageObject
+    //           .getRawPage()
+    //           .story.map(item => item.id)
+    //           .join(' ')}`,
+    //       })
+    //       if (!e.shiftKey) {
+    //         $page.nextAll().remove()
+    //       }
+    //       if (!e.shiftKey) {
+    //         lineup.removeAllAfterKey(key)
+    //       }
+    //       link.showResult(resultPage)
+    //     })
     .on('dragenter', evt => evt.preventDefault())
     .on('dragover', evt => evt.preventDefault())
     .on(

--- a/lib/refresh.js
+++ b/lib/refresh.js
@@ -368,9 +368,10 @@ const emitFooter = function ($footer, pageObject) {
   $footer.append(`\
 <a class="show-page-license" href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank">CC BY-SA 4.0</a> .
 <a class="show-page-source" href="${wiki.site(host).getDirectURL(slug)}.json" title="source">JSON</a> .
-<a href= "${wiki.site(host).getDirectURL(slug)}.html" date-slug="${slug}" target="${host}">${host} </a> .
-<a href= "#" class=search>search</a>\
+<a href= "${wiki.site(host).getDirectURL(slug)}.html" date-slug="${slug}" target="${host}">${host} </a> \
 `)
+  // link to federation search removed from footer until replacement available.
+  //  <a href= "#" class=search>search</a>
 }
 
 const editDate = function (journal) {


### PR DESCRIPTION
- Removed the federation search link from the page footer in the `refresh.js` file.
- Commented out the event handler for the federation search link click.

These changes ensure that users don't get directed to the currently unavailable federation search.