### PR TITLE
add ability to remove a wiki from the neighborhood

### DIFF
--- a/lib/neighborhood.js
+++ b/lib/neighborhood.js
@@ -37,6 +37,12 @@ const populateSiteInfoFor = function (site, neighborInfo) {
   }
 
   var refreshMap = function (site, neighborInfo) {
+    // guard for wiki removed from neighborhood
+    if (neighborInfo.sitemapRequestInflight != true && !wiki.neighborhood[site]) {
+      console.log(site, ' has been removed - ignore refresh')
+      return
+    }
+
     neighborInfo.sitemapRequestInflight = true
 
     return wiki.site(site).get('system/sitemap.json', function (err, gotData) {

--- a/lib/neighbors.js
+++ b/lib/neighbors.js
@@ -53,6 +53,14 @@ const formatNeighborTitle = function (site) {
   return title
 }
 
+// evict a wiki from the neighborhood, from Eric Dobbs (via matrix)
+const evict = site => {
+  const flagEl = Array.from($('.neighbor')).find(n => n.dataset.site == site)
+  flagEl.parentElement.removeChild(flagEl)
+  delete wiki.neighborhood[site]
+  $('body').trigger('new-neighbor-done')
+}
+
 const bind = function () {
   const $neighborhood = $('.neighborhood')
   $('body')
@@ -93,6 +101,25 @@ const bind = function () {
         })
       } else {
         link.doInternalLink('welcome-visitors', null, this.title.split('\n')[0])
+      }
+    })
+    .on('dragend', '.neighbor img', function (event) {
+      event.preventDefault()
+      console.log(event)
+      if (
+        event.originalEvent.y < window.innerHeight / 2 ||
+        event.originalEvent.screenX < window.screenX ||
+        event.originalEvent.screenX > window.screenX + window.outerWidth ||
+        event.originalEvent.screenY < window.screenY ||
+        event.originalEvent.screenY > window.screenY + window.outerHeight
+      ) {
+        const toRemove = event.originalEvent.target.title.split('\n')[0]
+        if (window.location.hostname != toRemove) {
+          console.log(`*** Removing ${toRemove} from neighborhood.`)
+          evict(toRemove)
+        } else {
+          console.log("can't remove origin wiki")
+        }
       }
     })
 }

--- a/lib/neighbors.js
+++ b/lib/neighbors.js
@@ -17,7 +17,7 @@ const hasLinks = element => Object.hasOwn(element, 'links')
 
 const flag = site =>
   `\
-<span class="neighbor" data-site="${site}">
+<span class="neighbor" data-site="${site}" ${site != window.location.hostname ? 'draggable="true"' : ''}>
 <div class="wait">
   <img src="${wiki.site(site).flag()}" title="${site}">
 </div>
@@ -58,13 +58,20 @@ const evict = site => {
   const flagEl = Array.from($('.neighbor')).find(n => n.dataset.site == site)
   flagEl.parentElement.removeChild(flagEl)
   delete wiki.neighborhood[site]
-  $('body').trigger('new-neighbor-done')
+  $('body').trigger('new-neighbor-done', site)
 }
 
 const bind = function () {
   const $neighborhood = $('.neighborhood')
   $('body')
-    .on('new-neighbor', (e, site) => $neighborhood.append(flag(site)))
+    .on('new-neighbor', (e, site) => {
+      $neighborhood.append(flag(site))
+      if (window.location.hostname != site) {
+        const elem = document.querySelector(`footer .neighbor[data-site="${site}"]`)
+        elem.addEventListener('dragstart', neighbor_dragstart)
+        elem.addEventListener('dragend', neighbor_dragend)
+      }
+    })
     .on('new-neighbor-done', () => {
       // let pageCount
       // try {
@@ -103,25 +110,33 @@ const bind = function () {
         link.doInternalLink('welcome-visitors', null, this.title.split('\n')[0])
       }
     })
-    .on('dragend', '.neighbor img', function (event) {
-      event.preventDefault()
-      console.log(event)
-      if (
-        event.originalEvent.y < window.innerHeight / 2 ||
-        event.originalEvent.screenX < window.screenX ||
-        event.originalEvent.screenX > window.screenX + window.outerWidth ||
-        event.originalEvent.screenY < window.screenY ||
-        event.originalEvent.screenY > window.screenY + window.outerHeight
-      ) {
-        const toRemove = event.originalEvent.target.title.split('\n')[0]
-        if (window.location.hostname != toRemove) {
-          console.log(`*** Removing ${toRemove} from neighborhood.`)
-          evict(toRemove)
-        } else {
-          console.log("can't remove origin wiki")
-        }
-      }
-    })
+
+  // Handlers for removing wiki from neighborhood
+
+  const neighbor_dragstart = event => {
+    console.log('neighbor dragstart', event)
+    document.querySelector('.main').addEventListener('drop', neighbor_drop)
+    event.dataTransfer.setData('text/plain', event.target.closest('span').dataset.site)
+  }
+
+  const neighbor_dragend = event => {
+    console.log('neighbor dragend', event)
+    document.querySelector('.main').removeEventListener('drop', neighbor_drop)
+  }
+
+  const neighbor_drop = event => {
+    console.log('neighbor drop', event)
+    event.stopPropagation()
+    event.preventDefault()
+    const toRemove = event.dataTransfer.getData('text/plain')
+    if (window.location.hostname != toRemove) {
+      console.log(`*** Removing ${toRemove} from neighborhood.`)
+      evict(toRemove)
+    } else {
+      console.log("*** Origin wiki can't be removed.")
+    }
+    return false
+  }
 }
 
 module.exports = { inject, bind }


### PR DESCRIPTION
The changes in this commit add the ability to remove a wiki from the neighborhood.

- Adding an `evict` function that removes a wiki from the neighborhood by finding the corresponding DOM element and removing it, updating the `wiki.neighborhood` object, and triggering an update of the page count.
- Adding a new event handler for the `dragend` event on the neighborhood flags. Checks if the drag ended outside the window, or more than half way up the window, and calls `evict` to remove the wiki from the neighborhood.