### PR TITLE
use narrow page on narrow devices

### DIFF
--- a/client/style/style.css
+++ b/client/style/style.css
@@ -260,7 +260,7 @@ div.image {
 /* end image plugin editor */
 
 .backlinks {
-  width: 420px;
+  /*width: 420px;*/
   margin-top: 2px;
   clear: both;
   background-color: #eeeeee;
@@ -294,7 +294,7 @@ div.image {
 }
 
 .journal.ui-draggable {
-  width: 420px;
+  /*width: 420px;*/
 }
 
 .action.fork {
@@ -529,6 +529,7 @@ textarea {
     padding: 0;
     flex: 0 0 100vw;
     font-size: .87rem;
+    overflow-x: unset;
   }
 }
 

--- a/client/style/style.css
+++ b/client/style/style.css
@@ -527,6 +527,8 @@ textarea {
     width: 1%;
     margin: 8px;
     padding: 0;
+    flex: 0 0 100vw;
+    font-size: .87rem;
   }
 }
 


### PR DESCRIPTION
Small adjustments view in the chrome mobile device simulator.

<img width="352" alt="image" src="https://github.com/user-attachments/assets/5dc5e224-d17f-4ac8-9c37-1f18dd41396d" />

This specific complaint is from Thompson who writes,
> When I send pages to others with the likelihood they will be read in their phone, I do so being aware that since the last major update, they don’t render well as the text width of the page is larger than the screen size, requiring some annoying side to side scrolling… I wonder if I’m the only one seeing this issue…
http://thompson.forage.ustawi.wiki/view/vagus-nerve

This css is from Baldur Bjarnason who suggested it as a quick fix without getting into page formatting theory.