### PR TITLE
adding support for relative external links

### DIFF
--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -47,12 +47,10 @@ resolve.resolveLinks = function (string, sanitize = escape) {
     }
   }
 
-  const external = (match, href, rest) => {
-    console.log('*** external', { href, rest })
-    return stash(
+  const external = (match, href, rest) =>
+    stash(
       `<a class="external" target="_blank" href="${href}" title="${href}" rel="noopener">${escape(rest)} <img src="/images/external-link-ltr-icon.png"></a>`,
     )
-  }
 
   // markup conversion happens in four phases:
   //   - unexpected markers are adulterated

--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -47,10 +47,12 @@ resolve.resolveLinks = function (string, sanitize = escape) {
     }
   }
 
-  const external = (match, href, protocol, rest) =>
-    stash(
-      `<a class="external" target="_blank" href="${href}" title="${href}" rel="nofollow">${escape(rest)} <img src="/images/external-link-ltr-icon.png"></a>`,
+  const external = (match, href, rest) => {
+    console.log('*** external', { href, rest })
+    return stash(
+      `<a class="external" target="_blank" href="${href}" title="${href}" rel="noopener">${escape(rest)} <img src="/images/external-link-ltr-icon.png"></a>`,
     )
+  }
 
   // markup conversion happens in four phases:
   //   - unexpected markers are adulterated
@@ -61,6 +63,6 @@ resolve.resolveLinks = function (string, sanitize = escape) {
   string = (string || '')
     .replace(/〖(\d+)〗/g, '〖 $1 〗')
     .replace(/\[\[([^\]]+)\]\]/gi, internal)
-    .replace(/\[((http|https|ftp):.*?) (.*?)\]/gi, external)
+    .replace(/\[((?:(?:https?|ftp):|\/).*?) (.*?)\]/gi, external)
   return sanitize(string).replace(/〖(\d+)〗/g, unstash)
 }


### PR DESCRIPTION
As mentioned on 20 Aug, adding support for using relative URLs in an external link. This removes the need for an external link to start with a protocol, though relative URLs must start with a `/`. 

Replace `rel="nofollow"`, as it has no real meaning, with `rel="noopener"`, so the new tab/window will not share browsing context. 

Use non-capturing groups for thing being matched (protocol), but we don't use in the replacement function, and remove them from the function's signature.

*There is a remote risk that there is text match somewhere that will match as an external link, when it shouldn't. Probably a risk worth taking? Thoughts.*