### PR TITLE
Fix build syntax to work on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "build:test": "npm run clean:test && node --no-warnings scripts/build-testclient.mjs",
     "prettier:format": "prettier --write './**/*.js'",
     "prettier:check": "prettier --check ./**/*.js",
-    "clean": "npm run clean:client; npm run clean:test",
+    "clean": "npm run clean:client && npm run clean:test",
     "clean:client": "rm client/client.js client/client.js.map meta-client.json",
     "clean:test": "rm client/test/testclient.js",
     "test": "mocha test/util.js test/random.js test/page.js test/lineup.js test/drop.js test/revision.js test/resolve.js test/wiki.js",

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   ],
   "scripts": {
     "build": "npm run test && npm run build:client && npm run build:test",
-    "build:client": "npm run clean:client; node --no-warnings scripts/build-client.mjs",
-    "build:test": "npm run clean:test; node --no-warnings scripts/build-testclient.mjs",
+    "build:client": "npm run clean:client && node --no-warnings scripts/build-client.mjs",
+    "build:test": "npm run clean:test && node --no-warnings scripts/build-testclient.mjs",
     "prettier:format": "prettier --write './**/*.js'",
     "prettier:check": "prettier --check ./**/*.js",
     "clean": "npm run clean:client; npm run clean:test",


### PR DESCRIPTION
The build script is using semicolons (;) to chain commands, but on Windows, npm needs && to properly chain commands. The semicolon is being treated as part of the script name.