### PR TITLE
sanitize wiki name before adding to neighbourhood

### DIFF
--- a/lib/neighborhood.js
+++ b/lib/neighborhood.js
@@ -124,6 +124,9 @@ neighborhood.retryNeighbor = function (site) {
 }
 
 neighborhood.registerNeighbor = function (site) {
+  if (site.endsWith(':')) {
+    site = site.slice(0, -1)
+  }
   if (neighborhood.sites[site]) {
     return
   }


### PR DESCRIPTION
Prevents propagation of `:` suffixed wiki.

Also see fedwiki/wiki-server#211