### PR TITLE
Enable video drops onto factory from links or files

### DIFF
--- a/lib/drop.js
+++ b/lib/drop.js
@@ -54,6 +54,25 @@ const isSvg = function (url) {
   return null
 }
 
+// HTML5 video subtype keyed by file extension / mime subtype.
+// Enable additional types (webm, ogg, ...) by adding entries here.
+const html5VideoTypes = {
+  mp4: 'mp4',
+  webm: 'webm',
+}
+
+const isHtml5Video = function (url, parsedURL) {
+  const match = parsedURL.pathname.match(/\.([a-z0-9]+)$/i)
+  if (!match) {
+    return null
+  }
+  const subtype = html5VideoTypes[match[1].toLowerCase()]
+  if (!subtype) {
+    return null
+  }
+  return { text: `HTML5 ${subtype} ${url}` }
+}
+
 const isVideo = function (url) {
   let parsedURL = new URL(url)
   // check if video dragged from search (Google)
@@ -87,7 +106,7 @@ const isVideo = function (url) {
     case 'www.ted.com':
       return { text: `TED ${parsedURL.pathname.substring(parsedURL.pathname.lastIndexOf('/') + 1)}` }
     default:
-      return null
+      return isHtml5Video(url, parsedURL)
   }
 }
 
@@ -135,4 +154,4 @@ const dispatch = handlers => event => {
   }
 }
 
-module.exports = { dispatch }
+module.exports = { dispatch, html5VideoTypes }

--- a/lib/drop.js
+++ b/lib/drop.js
@@ -55,7 +55,7 @@ const isSvg = function (url) {
 }
 
 // HTML5 video subtype keyed by file extension / mime subtype.
-// Enable additional types (webm, ogg, ...) by adding entries here.
+// Enable additional types (ogg, ...) by adding entries here.
 const html5VideoTypes = {
   mp4: 'mp4',
   webm: 'webm',

--- a/lib/factory.js
+++ b/lib/factory.js
@@ -212,6 +212,43 @@ const bind = function ($item, item) {
           syncEditAction()
         }
         reader.readAsText(file)
+      } else if (majorType === 'video') {
+        const subtype = drop.html5VideoTypes[minorType]
+        if (!subtype) {
+          punt({
+            name: file.name,
+            type: file.type,
+          })
+        } else {
+          // Reserved plugin asset path (same convention as plugins/image).
+          // Video has no dedicated upload endpoint, so use the assets plugin API.
+          const assetsPath = 'plugins/video'
+          document.documentElement.style.cursor = 'wait'
+          const data = new FormData()
+          data.append('assets', assetsPath)
+          data.append('uploads[]', file, file.name)
+          fetch('/plugin/assets/upload', { method: 'POST', body: data })
+            .then(function (response) {
+              if (!response.ok) {
+                throw new Error(response.statusText || 'Unable to upload video')
+              }
+              // Image stores a site-relative /assets/plugins/image/... URL; the video
+              // plugin HTML5 parser requires an absolute URL (new URL without base).
+              const assetUrl = `/assets/${assetsPath}/${encodeURIComponent(file.name)}`
+              const url = new URL(assetUrl, location.origin).href
+              addVideo({ text: `HTML5 ${subtype} ${url}` })
+            })
+            .catch(function (err) {
+              punt({
+                name: file.name,
+                type: file.type,
+                error: err.message,
+              })
+            })
+            .finally(function () {
+              document.documentElement.style.cursor = 'default'
+            })
+        }
       } else {
         punt({
           name: file.name,

--- a/lib/factory.js
+++ b/lib/factory.js
@@ -218,10 +218,12 @@ const bind = function ($item, item) {
           punt({
             name: file.name,
             type: file.type,
+            size: file.size,
+            fileName: file.fileName,
+            lastModified: file.lastModified,
           })
         } else {
-          // Reserved plugin asset path (same convention as plugins/image).
-          // Video has no dedicated upload endpoint, so use the assets plugin API.
+          // Video plugin has no dedicated upload endpoint, so use the assets plugin API.
           const assetsPath = 'plugins/video'
           document.documentElement.style.cursor = 'wait'
           const data = new FormData()
@@ -232,8 +234,6 @@ const bind = function ($item, item) {
               if (!response.ok) {
                 throw new Error(response.statusText || 'Unable to upload video')
               }
-              // Image stores a site-relative /assets/plugins/image/... URL; the video
-              // plugin HTML5 parser requires an absolute URL (new URL without base).
               const assetUrl = `/assets/${assetsPath}/${encodeURIComponent(file.name)}`
               const url = new URL(assetUrl, location.origin).href
               addVideo({ text: `HTML5 ${subtype} ${url}` })
@@ -242,6 +242,9 @@ const bind = function ($item, item) {
               punt({
                 name: file.name,
                 type: file.type,
+                size: file.size,
+                fileName: file.fileName,
+                lastModified: file.lastModified,
                 error: err.message,
               })
             })

--- a/lib/factory.js
+++ b/lib/factory.js
@@ -96,6 +96,14 @@ const bind = function ($item, item) {
     syncEditAction()
   }
 
+  const requireOwnerUpload = function (data) {
+    item.prompt =
+      'Upload Requires Login\nVideo files can only be uploaded when you are signed in as the owner of this wiki.'
+    data.userAgent = navigator.userAgent
+    item.punt = data
+    syncEditAction()
+  }
+
   const addReference = data =>
     wiki.site(data.site).get(`${data.slug}.json`, function (err, remote) {
       if (!err) {
@@ -215,44 +223,35 @@ const bind = function ($item, item) {
       } else if (majorType === 'video') {
         const subtype = drop.html5VideoTypes[minorType]
         if (!subtype) {
-          punt({
-            name: file.name,
-            type: file.type,
-            size: file.size,
-            fileName: file.fileName,
-            lastModified: file.lastModified,
-            error: 'unsupported video type',
-          })
-        } else {
-          // Video plugin has no dedicated upload endpoint, so use the assets plugin API.
-          const assetsPath = 'plugins/video'
-          document.documentElement.style.cursor = 'wait'
-          const data = new FormData()
-          data.append('assets', assetsPath)
-          data.append('uploads[]', file, file.name)
-          fetch('/plugin/assets/upload', { method: 'POST', body: data })
-            .then(function (response) {
-              if (!response.ok) {
-                throw new Error(response.statusText || 'Unable to upload video')
-              }
-              const assetUrl = `/assets/${assetsPath}/${encodeURIComponent(file.name)}`
-              const url = new URL(assetUrl, location.origin).href
-              addVideo({ text: `HTML5 ${subtype} ${url}` })
-            })
-            .catch(function (err) {
-              punt({
-                name: file.name,
-                type: file.type,
-                size: file.size,
-                fileName: file.fileName,
-                lastModified: file.lastModified,
-                error: err.message,
-              })
-            })
-            .finally(function () {
-              document.documentElement.style.cursor = 'default'
-            })
+          return punt({ name: file.name, type: file.type, error: 'unsupported video type' })
         }
+        if (typeof isOwner !== 'undefined' && !isOwner) {
+          return requireOwnerUpload({ name: file.name, type: file.type, error: 'must be owner to upload' })
+        }
+        // Video plugin has no dedicated upload endpoint, so use the assets plugin API.
+        const assetsPath = 'plugins/video'
+        document.documentElement.style.cursor = 'wait'
+        const data = new FormData()
+        data.append('assets', assetsPath)
+        data.append('uploads[]', file, file.name)
+        fetch('/plugin/assets/upload', { method: 'POST', body: data })
+          .then(function (response) {
+            if (response.status === 403) {
+              return requireOwnerUpload({ name: file.name, type: file.type, error: 'must be owner to upload' })
+            }
+            if (!response.ok) {
+              throw new Error(response.statusText || 'Unable to upload video')
+            }
+            const assetUrl = `/assets/${assetsPath}/${encodeURIComponent(file.name)}`
+            const url = new URL(assetUrl, location.origin).href
+            addVideo({ text: `HTML5 ${subtype} ${url}` })
+          })
+          .catch(function (err) {
+            punt({ name: file.name, type: file.type, error: err.message })
+          })
+          .finally(function () {
+            document.documentElement.style.cursor = 'default'
+          })
       } else {
         punt({
           name: file.name,

--- a/lib/factory.js
+++ b/lib/factory.js
@@ -221,6 +221,7 @@ const bind = function ($item, item) {
             size: file.size,
             fileName: file.fileName,
             lastModified: file.lastModified,
+            error: 'unsupported video type',
           })
         } else {
           // Video plugin has no dedicated upload endpoint, so use the assets plugin API.


### PR DESCRIPTION
Support dropping HTML5 video files and URLs onto factory

Upload mp4/webm via the assets plugin to "plugins/video/" and recognize direct .mp4/.webm URL drops, creating video items with the correct subtype instead of punting.


Consider adding an asset item onto about-video-plugin page showing all videos in "plugins/video/"