### PR TITLE
Persist wiki edit mode and sync it on login/logout

### DIFF
--- a/lib/legacy.js
+++ b/lib/legacy.js
@@ -458,21 +458,37 @@ Installed plugins offer these utility pages:\
       })
     })
 
+  const setEditState = function (editState) {
+    $('.editEnable').toggle(!!editState)
+    localStorage.setItem('wikiEditEnabled', !!editState)
+    $('.page').each(function () {
+      const $page = $(this)
+      refresh.rebuildPage(lineup.atKey($page.data('key')), $page.empty())
+    })
+  }
   // $('.editEnable').is(':visible')
   $('<span>&nbsp; wiki <span class=editEnable>✔︎</span> &nbsp; </span>')
     .css({ cursor: 'pointer' })
     .appendTo('footer')
     .on('click', function () {
-      $('.editEnable').toggle()
-      $('.page').each(function () {
-        const $page = $(this)
-        const pageObject = lineup.atKey($page.data('key'))
-        refresh.rebuildPage(pageObject, $page.empty())
-      })
+      setEditState(!$('.editEnable').is(':visible'))
     })
-  /*global isAuthenticated */ // isAuthenticated global is set while loading the page.
-  if (!isAuthenticated) {
-    $('.editEnable').toggle()
+
+  // Prefer a saved wiki ✔︎ choice; otherwise default by login and viewport.
+  const storedEditState = localStorage.getItem('wikiEditEnabled')
+  const defaultEditState = isAuthenticated && !matchMedia('(max-width: 490px)').matches
+  $('.editEnable').toggle(storedEditState != null ? storedEditState === 'true' : defaultEditState)
+
+  // #security is rewritten on login/logout — sync wiki ✔︎ only when auth actually flips.
+  const securityEl = $('#security')[0]
+  if (securityEl) {
+    let lastAuthState = !!isAuthenticated
+    new MutationObserver(function () {
+      const authState = !!isAuthenticated
+      if (authState === lastAuthState) return
+      lastAuthState = authState
+      setEditState(authState)
+    }).observe(securityEl, { childList: true })
   }
 
   target.bind()

--- a/lib/legacy.js
+++ b/lib/legacy.js
@@ -487,7 +487,8 @@ Installed plugins offer these utility pages:\
       const authState = !!isAuthenticated
       if (authState === lastAuthState) return
       lastAuthState = authState
-      setEditState(authState)
+      // Login follows viewport default (mobile off); logout clears edit.
+      setEditState(authState && !matchMedia('(max-width: 490px)').matches)
     }).observe(securityEl, { childList: true })
   }
 


### PR DESCRIPTION
## Summary
- Persist the footer **wiki ✔︎** toggle in `localStorage` (`wikiEditEnable`) so a manual choice survives reload.
- When no preference is saved, default edit **on** for authenticated desktop and **off** for logged-out users or narrow viewports (`max-width: 490px`, same breakpoint as page CSS).
- On login/logout (security footer `#security` update), match classic wiki behavior: **login → edit on** (any viewport), **logout → edit off**, including when a prior preference was saved.
- Only react when `isAuthenticated` actually changes, so the security plugin’s initial footer paint does not overwrite a saved preference.