### PR TITLE
Keep incremental search open after results are added to lineup, and improve result keyboard UX

### DIFF
--- a/lib/active.js
+++ b/lib/active.js
@@ -50,7 +50,6 @@ function scrollTo($page) {
 
 active.set = function ($page, noScroll) {
   if ($page == null) return
-  $('.incremental-search').remove()
   $page = $($page)
   $('.active').removeClass('active')
   $page.addClass('active')

--- a/lib/search.js
+++ b/lib/search.js
@@ -68,7 +68,10 @@ const createSearch = function ({ neighborhood }) {
           // ensure that name is a string (using string interpolation)
           name = `${name}`
           pageHandler.context = $(e.target).attr('title').split(' => ')
-          return finishClick(e, name)
+          finishClick(e, name)
+          // keep focus on clicked result so more results can be opened
+          e.target.focus()
+          return false
         })
         .on('click', 'img.remote', function (e) {
           // expand to handle click on temporary flag

--- a/lib/searchbox.js
+++ b/lib/searchbox.js
@@ -24,9 +24,28 @@ const bind = function () {
     $(this).val('')
   })
 
-  $('input.search').on('focus', function () {
+  $('input.search').on('focus click', function () {
     const searchQuery = $(this).val()
     search.incrementalSearch(searchQuery)
+  })
+
+  // Tab cycles result links, but won't tab outside the search box or results overlay while its open
+  $(document).on('keydown', function (e) {
+    if (!$('.incremental-search').length) return
+    if (e.keyCode === 27) {
+      return $('.incremental-search').remove()
+    } // 27 == escape
+    if (e.keyCode !== 9) return // 9 == tab
+    const resultLinks = [$('input.search')[0], ...$('.incremental-search a[href]').get()]
+    const i = resultLinks.indexOf(document.activeElement)
+    if (i < 0) return
+    e.preventDefault()
+    resultLinks[(i + (e.shiftKey ? -1 : 1) + resultLinks.length) % resultLinks.length].focus()
+  })
+
+  // click-away closes results overlay
+  $(document).on('mousedown', function (e) {
+    if (!$(e.target).closest('.searchbox').length) $('.incremental-search').remove()
   })
 
   return $('input.search').on('input', function () {

--- a/lib/searchbox.js
+++ b/lib/searchbox.js
@@ -45,7 +45,7 @@ const bind = function () {
 
   // click-away closes results overlay
   $(document).on('mousedown', function (e) {
-    if (!$(e.target).closest('.searchbox').length) $('.incremental-search').remove()
+    if (!$(e.target).closest('.searchbox, .incremental-search').length) $('.incremental-search').remove()
   })
 
   return $('input.search').on('input', function () {


### PR DESCRIPTION
## Summary
- Stop clearing `.incremental-search` when a page becomes active (fixes mech/page opens dismissing search mid-query).
- Opening a result keeps focus on that link so you can can keep opening more results
- Tab cycles through the search input and result links and doesn't escape into the rest of the wiki; Escape or click-away dismisses.
- Clicking the search field again re-shows results if the query is still there (e.g. after Escape).

This feature was inspired by watching the mech add results to the lineup on this site:
http://jargon.fed.wiki/

I found myself wanting to search for the pages that flashed in front of me, and realized the search results were quickly closed as soon as the mech added a new page to the lineup, because it was made active and stole focus.

