### PR TITLE
Isolate HTML item styles so they cannot restyle site layout.

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -246,6 +246,35 @@ plugin.emit = async function (div, item, done = () => {}) {
       throw TypeError(`Can't find plugin for '${item.type}'`)
     }
     await script.emit(div, item)
+    // Prevent HTML <style> from restyling the lineup / document.
+    if (item.type === 'html' && div[0]) {
+      const el = div[0]
+      const scope = `[data-style-scope="${item.id}"]`
+      el.setAttribute('data-style-scope', item.id)
+      // Retag landmark elements so page/site layout selectors cannot match them,
+      // and rewrite the item's CSS so its theme rules still apply.
+      const roles = { footer: 'contentinfo', header: 'banner', main: 'main', nav: 'navigation', aside: 'complementary' }
+      for (const node of [...el.querySelectorAll(Object.keys(roles).join(','))]) {
+        const tag = node.localName
+        const next = document.createElement('div')
+        next.setAttribute('data-wiki-html', tag)
+        next.setAttribute('role', roles[tag])
+        for (const { name, value } of node.attributes) {
+          if (name !== 'role') next.setAttribute(name, value)
+        }
+        next.append(...node.childNodes)
+        node.replaceWith(next)
+      }
+      const retarget = css =>
+        css.replace(/(^|[^.\w-])(footer|header|main|nav|aside)\b/g, (_, pre, tag) => `${pre}[data-wiki-html="${tag}"]`)
+      // Contain absolute/fixed theme layout (fixed escapes position:relative alone).
+      if (!el.style.position) el.style.position = 'relative'
+      if (!el.style.transform) el.style.transform = 'translateZ(0)'
+      for (const style of el.querySelectorAll('style:not([data-wiki-scoped])')) {
+        style.textContent = `@scope (${scope}){${retarget(style.textContent)}}`
+        style.setAttribute('data-wiki-scoped', '')
+      }
+    }
   } catch (err) {
     console.log('plugin error', err)
     error(err, script)


### PR DESCRIPTION
## Summary
HTML items can embed `<style>` (and landmark tags like `<footer>` / `<header>`) that escape the item and restyle the host wiki — the lineup, neighborhood bar, and other site UI.

This change keeps those themes working inside the item, while stopping them from affecting the rest of the page:

- Wrap the item’s `<style>` rules in `@scope` keyed to the item id
- Retag landmark elements (`footer` / `header` / `main` / `nav` / `aside`) to `div[data-wiki-html="…"]` with matching roles
- Rewrite those selectors in the item CSS so themes still apply
- Contain fixed/absolute theme layout with `position: relative` + `translateZ(0)`

### Demo: theme pollution (`grok.surf`)
- Broken: [fed.wiki …/grok.surf/welcome-visitors](http://fed.wiki/view/welcome-visitors/grok.surf/welcome-visitors)
- Fixed: [aolc.cc …/grok.surf/welcome-visitors](https://aolc.cc/view/welcome-visitors/grok.surf/welcome-visitors)

### Why landmark retag is required (not only `@scope`)
`@scope` limits where *item* CSS applies. It does **not** stop *host* CSS from matching elements inside the item.

Federated Wiki’s site stylesheet uses bare selectors such as `footer { position: fixed; … }`. Any HTML item that emits a real `<footer>` (common in page themes for credit/legal bars) becomes another match for that rule and can be pinned over the host’s own bottom UI. Scoping the item’s stylesheet alone cannot prevent that; the element has to stop being a `footer` (or similar landmark) in the DOM, with item CSS rewritten to follow.